### PR TITLE
Workflow adjustments for DST and manual triggers

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:  # Allows manual trigger
     inputs:
         env:
-          description: "Environment to deploy to"
+          description: "Environment to run on"
           required: true
           default: "dev"
           type: choice
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'schedule' && 'production' || inputs.env }}
     steps:
-      - name: Deploying to selected environment
-        run: echo "Deploying to ${{ github.event_name == 'schedule' && 'production' || inputs.env }}"
+      - name: Deploying on selected environment
+        run: echo "Deploying on ${{ github.event_name == 'schedule' && 'production' || inputs.env }}"
 
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -2,7 +2,7 @@ name: Lifetime Bot Automation
 
 on:
   schedule:
-    - cron: '30 15 * * 0-4'  # Runs at 9:30 AM from Sunday to Thursday
+    - cron: '30 14 * * 0-4'  # Runs at 9:30 AM CST from Sunday to Thursday
   workflow_dispatch:  # Allows manual trigger
     inputs:
         env:

--- a/lifetime_bot.py
+++ b/lifetime_bot.py
@@ -439,6 +439,13 @@ def wait_until_utc(target_utc_time: str):
 
     :param target_utc_time: The UTC time to wait until (e.g., "16:00:00").
     """
+    # Check if RUN_ON_SCHEDULE is false
+    if os.getenv("RUN_ON_SCHEDULE", "false").lower() == "false":
+        print("RUN_ON_SCHEDULE is false, running main() immediately.")
+        main()
+        return  # Exit the function
+    
+    # Existing code to wait until the target UTC time
     now = datetime.datetime.now(datetime.timezone.utc)
     target = datetime.datetime.strptime(target_utc_time, "%H:%M:%S").time()
     target_datetime = datetime.datetime.combine(now.date(), target).replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
Adjusting cron schedule for DST

Bypassing wait_until_utc() when RUN_ON_SCHEDULE is set to false