### PR TITLE
Replace email-to-SMS gateway with Twilio for SMS notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 LIFETIME_USERNAME=your_email@example.com
 LIFETIME_PASSWORD=your_password
 
-# Club name as shown on the club directory (without "Life Time - " prefix)
+# Club name as shown on the club directory
 # Find your club name at: https://my.lifetime.life/view-all-clubs.html
 # Examples:
 #   San Antonio 281
@@ -74,16 +74,22 @@ SMTP_SERVER=smtp.gmail.com
 SMTP_PORT=587
 
 # ==============================================================================
-# SMS CONFIGURATION
+# SMS CONFIGURATION (Twilio)
 # Only required if NOTIFICATION_METHOD is "sms" or "both"
 # ==============================================================================
-# Supported carriers:
-#   att, tmobile, verizon, sprint, boost, cricket,
-#   metro, uscellular, virgin, xfinity, googlefi
-SMS_CARRIER=att
+# Sign up for free at: https://www.twilio.com/try-twilio
+# Free trial includes $15 credit (~1,800+ SMS messages)
+#
+# Find your credentials at: https://console.twilio.com
+# Account SID and Auth Token are on the main dashboard
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your_auth_token_here
 
-# Phone number - digits only, no dashes or spaces
-SMS_NUMBER=1234567890
+# Your Twilio phone number (from the console, format: +1XXXXXXXXXX)
+TWILIO_FROM_NUMBER=+15551234567
+
+# Your personal phone number to receive SMS (format: +1XXXXXXXXXX)
+SMS_NUMBER=+15129819861
 
 # ==============================================================================
 # BOT BEHAVIOR

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -58,7 +58,9 @@ jobs:
           echo "START_TIME=${{ vars.START_TIME }}" >> .env
           echo "END_TIME=${{ vars.END_TIME }}" >> .env
           echo "NOTIFICATION_METHOD=${{ vars.NOTIFICATION_METHOD }}" >> .env
-          echo "SMS_CARRIER=${{ vars.SMS_CARRIER }}" >> .env
+          echo "TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID }}" >> .env
+          echo "TWILIO_AUTH_TOKEN=${{ secrets.TWILIO_AUTH_TOKEN }}" >> .env
+          echo "TWILIO_FROM_NUMBER=${{ secrets.TWILIO_FROM_NUMBER }}" >> .env
           echo "SMS_NUMBER=${{ secrets.SMS_NUMBER }}" >> .env
 
       - name: Run Lifetime Bot
@@ -81,5 +83,7 @@ jobs:
           START_TIME: ${{ vars.START_TIME }}
           END_TIME: ${{ vars.END_TIME }}
           NOTIFICATION_METHOD: ${{ vars.NOTIFICATION_METHOD }}
-          SMS_CARRIER: ${{ vars.SMS_CARRIER }}
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}
           SMS_NUMBER: ${{ secrets.SMS_NUMBER }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "selenium>=4.0.0",
     "webdriver-manager>=4.0.0",
+    "twilio>=8.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/lifetime_bot/bot.py
+++ b/src/lifetime_bot/bot.py
@@ -38,7 +38,7 @@ class LifetimeReservationBot:
     def _setup_notifications(self) -> None:
         """Initialize notification services."""
         self.email_service = EmailNotificationService(self.config.email)
-        self.sms_service = SMSNotificationService(self.config.sms, self.config.email)
+        self.sms_service = SMSNotificationService(self.config.sms)
 
     def _setup_webdriver(self) -> None:
         """Initialize the WebDriver."""

--- a/src/lifetime_bot/config.py
+++ b/src/lifetime_bot/config.py
@@ -3,26 +3,12 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal
 
 from dotenv import load_dotenv
 
 NotificationMethod = Literal["email", "sms", "both"]
-
-SMS_GATEWAYS: dict[str, str] = {
-    "att": "mms.att.net",
-    "tmobile": "tmomail.net",
-    "verizon": "vtext.com",
-    "sprint": "messaging.sprintpcs.com",
-    "boost": "sms.myboostmobile.com",
-    "cricket": "sms.cricketwireless.net",
-    "metro": "mymetropcs.com",
-    "uscellular": "email.uscc.net",
-    "virgin": "vmobl.com",
-    "xfinity": "vtext.com",
-    "googlefi": "msg.fi.google.com",
-}
 
 
 @dataclass
@@ -53,32 +39,28 @@ class EmailConfig:
 
 @dataclass
 class SMSConfig:
-    """SMS notification configuration."""
+    """SMS notification configuration using Twilio."""
 
-    number: str
-    carrier: str
-    gateways: dict[str, str] = field(default_factory=lambda: SMS_GATEWAYS.copy())
+    account_sid: str
+    auth_token: str
+    from_number: str
+    to_number: str
 
     @classmethod
     def from_env(cls) -> SMSConfig:
         """Create SMSConfig from environment variables."""
         return cls(
-            number=os.getenv("SMS_NUMBER", ""),
-            carrier=os.getenv("SMS_CARRIER", "").lower(),
+            account_sid=os.getenv("TWILIO_ACCOUNT_SID", ""),
+            auth_token=os.getenv("TWILIO_AUTH_TOKEN", ""),
+            from_number=os.getenv("TWILIO_FROM_NUMBER", ""),
+            to_number=os.getenv("SMS_NUMBER", ""),
         )
 
     def is_valid(self) -> bool:
         """Check if SMS configuration is valid."""
-        return bool(self.number and self.carrier and self.carrier in self.gateways)
-
-    def get_gateway_email(self) -> str:
-        """Get the email-to-SMS gateway address."""
-        if not self.is_valid():
-            raise ValueError(
-                f"Invalid SMS configuration. Carrier '{self.carrier}' not in supported carriers: "
-                f"{', '.join(self.gateways.keys())}"
-            )
-        return f"{self.number}@{self.gateways[self.carrier]}"
+        return bool(
+            self.account_sid and self.auth_token and self.from_number and self.to_number
+        )
 
 
 @dataclass

--- a/src/lifetime_bot/notifications/sms.py
+++ b/src/lifetime_bot/notifications/sms.py
@@ -1,34 +1,30 @@
-"""SMS notification service using email-to-SMS gateways."""
+"""SMS notification service using Twilio."""
 
 from __future__ import annotations
 
-import smtplib
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+from twilio.rest import Client
 
-from lifetime_bot.config import EmailConfig, SMSConfig
+from lifetime_bot.config import SMSConfig
 from lifetime_bot.notifications.base import NotificationService
 
 
 class SMSNotificationService(NotificationService):
-    """SMS notification service using email-to-SMS gateways."""
+    """SMS notification service using Twilio."""
 
-    def __init__(self, sms_config: SMSConfig, email_config: EmailConfig) -> None:
+    def __init__(self, sms_config: SMSConfig) -> None:
         """Initialize the SMS notification service.
 
         Args:
-            sms_config: SMS configuration containing carrier and number.
-            email_config: Email configuration for SMTP settings.
+            sms_config: SMS configuration containing Twilio credentials.
         """
         self.sms_config = sms_config
-        self.email_config = email_config
 
     def is_configured(self) -> bool:
         """Check if SMS configuration is valid."""
-        return self.sms_config.is_valid() and self.email_config.is_valid()
+        return self.sms_config.is_valid()
 
     def send(self, subject: str, message: str) -> bool:
-        """Send an SMS notification via email-to-SMS gateway.
+        """Send an SMS notification via Twilio.
 
         Args:
             subject: Message subject (prefixed to the message).
@@ -38,24 +34,19 @@ class SMSNotificationService(NotificationService):
             True if SMS was sent successfully, False otherwise.
         """
         if not self.is_configured():
-            error_msg = "SMS configuration incomplete. Check SMS_NUMBER and SMS_CARRIER."
+            error_msg = "SMS configuration incomplete. Check Twilio credentials."
             print(f"{error_msg}")
             return False
 
         try:
             sms_message = f"{subject}: {message}"
-            sms_email = self.sms_config.get_gateway_email()
 
-            msg = MIMEMultipart()
-            msg["From"] = self.email_config.sender
-            msg["To"] = sms_email
-            msg["Subject"] = "LT Bot"
-            msg.attach(MIMEText(sms_message, "plain"))
-
-            with smtplib.SMTP(self.email_config.smtp_server, self.email_config.smtp_port) as server:
-                server.starttls()
-                server.login(self.email_config.sender, self.email_config.password)
-                server.send_message(msg)
+            client = Client(self.sms_config.account_sid, self.sms_config.auth_token)
+            client.messages.create(
+                body=sms_message,
+                from_=self.sms_config.from_number,
+                to=self.sms_config.to_number,
+            )
 
             return True
         except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,10 @@ def email_config() -> EmailConfig:
 def sms_config() -> SMSConfig:
     """Create a test SMS configuration."""
     return SMSConfig(
-        number="1234567890",
-        carrier="att",
+        account_sid="ACtest123456789",
+        auth_token="test_auth_token",
+        from_number="+15551234567",
+        to_number="+15559876543",
     )
 
 
@@ -97,8 +99,10 @@ def env_vars() -> dict[str, str]:
         "EMAIL_RECEIVER": "receiver@gmail.com",
         "SMTP_SERVER": "smtp.gmail.com",
         "SMTP_PORT": "587",
-        "SMS_NUMBER": "1234567890",
-        "SMS_CARRIER": "att",
+        "TWILIO_ACCOUNT_SID": "ACtest123456789",
+        "TWILIO_AUTH_TOKEN": "test_auth_token",
+        "TWILIO_FROM_NUMBER": "+15551234567",
+        "SMS_NUMBER": "+15559876543",
         "NOTIFICATION_METHOD": "email",
         "RUN_ON_SCHEDULE": "false",
         "HEADLESS": "true",

--- a/tests/integration/test_config_integration.py
+++ b/tests/integration/test_config_integration.py
@@ -43,11 +43,12 @@ class TestBotConfigIntegration:
             assert config.email.smtp_port == 587
             assert config.email.is_valid() is True
 
-            # Verify SMS config
-            assert config.sms.number == "1234567890"
-            assert config.sms.carrier == "att"
+            # Verify SMS config (Twilio)
+            assert config.sms.account_sid == "ACtest123456789"
+            assert config.sms.auth_token == "test_auth_token"
+            assert config.sms.from_number == "+15551234567"
+            assert config.sms.to_number == "+15559876543"
             assert config.sms.is_valid() is True
-            assert config.sms.get_gateway_email() == "1234567890@mms.att.net"
 
             # Verify bot settings
             assert config.notification_method == "email"
@@ -77,16 +78,20 @@ class TestBotConfigIntegration:
             "LIFETIME_CLUB_NAME": "Test Club",
             "LIFETIME_CLUB_STATE": "CA",
             "NOTIFICATION_METHOD": "sms",
-            "SMS_NUMBER": "5551234567",
-            "SMS_CARRIER": "verizon",
+            "TWILIO_ACCOUNT_SID": "ACtest123",
+            "TWILIO_AUTH_TOKEN": "authtoken123",
+            "TWILIO_FROM_NUMBER": "+15551234567",
+            "SMS_NUMBER": "+15559876543",
         }
         with patch.dict(os.environ, env, clear=True):
             config = BotConfig.from_env(reload_env=False)
 
             assert config.notification_method == "sms"
-            assert config.sms.number == "5551234567"
-            assert config.sms.carrier == "verizon"
-            assert config.sms.get_gateway_email() == "5551234567@vtext.com"
+            assert config.sms.account_sid == "ACtest123"
+            assert config.sms.auth_token == "authtoken123"
+            assert config.sms.from_number == "+15551234567"
+            assert config.sms.to_number == "+15559876543"
+            assert config.sms.is_valid() is True
 
     def test_config_with_both_notifications(self) -> None:
         """Test configuration with both notification methods."""
@@ -99,8 +104,10 @@ class TestBotConfigIntegration:
             "EMAIL_SENDER": "sender@gmail.com",
             "EMAIL_PASSWORD": "emailpass",
             "EMAIL_RECEIVER": "receiver@gmail.com",
-            "SMS_NUMBER": "5551234567",
-            "SMS_CARRIER": "tmobile",
+            "TWILIO_ACCOUNT_SID": "ACtest123",
+            "TWILIO_AUTH_TOKEN": "authtoken123",
+            "TWILIO_FROM_NUMBER": "+15551234567",
+            "SMS_NUMBER": "+15559876543",
         }
         with patch.dict(os.environ, env, clear=True):
             config = BotConfig.from_env(reload_env=False)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import pytest
 
 from lifetime_bot.config import (
-    SMS_GATEWAYS,
     BotConfig,
     ClassConfig,
     ClubConfig,
@@ -84,57 +83,71 @@ class TestSMSConfig:
 
     def test_init(self, sms_config: SMSConfig) -> None:
         """Test SMSConfig initialization."""
-        assert sms_config.number == "1234567890"
-        assert sms_config.carrier == "att"
-        assert sms_config.gateways == SMS_GATEWAYS
+        assert sms_config.account_sid == "ACtest123456789"
+        assert sms_config.auth_token == "test_auth_token"
+        assert sms_config.from_number == "+15551234567"
+        assert sms_config.to_number == "+15559876543"
 
     def test_from_env(self, mock_env: dict[str, str]) -> None:
         """Test creating SMSConfig from environment variables."""
         config = SMSConfig.from_env()
-        assert config.number == "1234567890"
-        assert config.carrier == "att"
+        assert config.account_sid == "ACtest123456789"
+        assert config.auth_token == "test_auth_token"
+        assert config.from_number == "+15551234567"
+        assert config.to_number == "+15559876543"
 
     def test_from_env_defaults(self) -> None:
         """Test SMSConfig defaults when env vars are missing."""
         with patch.dict(os.environ, {}, clear=True):
             config = SMSConfig.from_env()
-            assert config.number == ""
-            assert config.carrier == ""
+            assert config.account_sid == ""
+            assert config.auth_token == ""
+            assert config.from_number == ""
+            assert config.to_number == ""
 
     def test_is_valid_true(self, sms_config: SMSConfig) -> None:
         """Test is_valid returns True for valid config."""
         assert sms_config.is_valid() is True
 
-    def test_is_valid_false_missing_number(self) -> None:
-        """Test is_valid returns False when number is missing."""
-        config = SMSConfig(number="", carrier="att")
+    def test_is_valid_false_missing_account_sid(self) -> None:
+        """Test is_valid returns False when account_sid is missing."""
+        config = SMSConfig(
+            account_sid="",
+            auth_token="token",
+            from_number="+15551234567",
+            to_number="+15559876543",
+        )
         assert config.is_valid() is False
 
-    def test_is_valid_false_missing_carrier(self) -> None:
-        """Test is_valid returns False when carrier is missing."""
-        config = SMSConfig(number="1234567890", carrier="")
+    def test_is_valid_false_missing_auth_token(self) -> None:
+        """Test is_valid returns False when auth_token is missing."""
+        config = SMSConfig(
+            account_sid="ACtest123",
+            auth_token="",
+            from_number="+15551234567",
+            to_number="+15559876543",
+        )
         assert config.is_valid() is False
 
-    def test_is_valid_false_invalid_carrier(self) -> None:
-        """Test is_valid returns False for invalid carrier."""
-        config = SMSConfig(number="1234567890", carrier="invalid_carrier")
+    def test_is_valid_false_missing_from_number(self) -> None:
+        """Test is_valid returns False when from_number is missing."""
+        config = SMSConfig(
+            account_sid="ACtest123",
+            auth_token="token",
+            from_number="",
+            to_number="+15559876543",
+        )
         assert config.is_valid() is False
 
-    def test_get_gateway_email(self, sms_config: SMSConfig) -> None:
-        """Test get_gateway_email returns correct email."""
-        assert sms_config.get_gateway_email() == "1234567890@mms.att.net"
-
-    def test_get_gateway_email_all_carriers(self) -> None:
-        """Test get_gateway_email for all supported carriers."""
-        for carrier, gateway in SMS_GATEWAYS.items():
-            config = SMSConfig(number="5551234567", carrier=carrier)
-            assert config.get_gateway_email() == f"5551234567@{gateway}"
-
-    def test_get_gateway_email_invalid_carrier(self) -> None:
-        """Test get_gateway_email raises error for invalid carrier."""
-        config = SMSConfig(number="1234567890", carrier="invalid")
-        with pytest.raises(ValueError, match="Invalid SMS configuration"):
-            config.get_gateway_email()
+    def test_is_valid_false_missing_to_number(self) -> None:
+        """Test is_valid returns False when to_number is missing."""
+        config = SMSConfig(
+            account_sid="ACtest123",
+            auth_token="token",
+            from_number="+15551234567",
+            to_number="",
+        )
+        assert config.is_valid() is False
 
 
 class TestClassConfig:

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -86,96 +86,103 @@ class TestEmailNotificationService:
 class TestSMSNotificationService:
     """Tests for SMSNotificationService."""
 
-    def test_init(
-        self, sms_config: SMSConfig, email_config: EmailConfig
-    ) -> None:
+    def test_init(self, sms_config: SMSConfig) -> None:
         """Test SMSNotificationService initialization."""
-        service = SMSNotificationService(sms_config, email_config)
+        service = SMSNotificationService(sms_config)
         assert service.sms_config == sms_config
-        assert service.email_config == email_config
 
-    def test_is_configured_true(
-        self, sms_config: SMSConfig, email_config: EmailConfig
-    ) -> None:
+    def test_is_configured_true(self, sms_config: SMSConfig) -> None:
         """Test is_configured returns True for valid config."""
-        service = SMSNotificationService(sms_config, email_config)
+        service = SMSNotificationService(sms_config)
         assert service.is_configured() is True
 
-    def test_is_configured_false_invalid_sms(
-        self, email_config: EmailConfig
-    ) -> None:
-        """Test is_configured returns False for invalid SMS config."""
-        sms_config = SMSConfig(number="", carrier="")
-        service = SMSNotificationService(sms_config, email_config)
+    def test_is_configured_false_missing_account_sid(self) -> None:
+        """Test is_configured returns False when account_sid is missing."""
+        sms_config = SMSConfig(
+            account_sid="",
+            auth_token="token",
+            from_number="+15551234567",
+            to_number="+15559876543",
+        )
+        service = SMSNotificationService(sms_config)
         assert service.is_configured() is False
 
-    def test_is_configured_false_invalid_email(
-        self, sms_config: SMSConfig
-    ) -> None:
-        """Test is_configured returns False for invalid email config."""
-        email_config = EmailConfig(sender="", password="", receiver="")
-        service = SMSNotificationService(sms_config, email_config)
+    def test_is_configured_false_missing_to_number(self) -> None:
+        """Test is_configured returns False when to_number is missing."""
+        sms_config = SMSConfig(
+            account_sid="ACtest123",
+            auth_token="token",
+            from_number="+15551234567",
+            to_number="",
+        )
+        service = SMSNotificationService(sms_config)
         assert service.is_configured() is False
 
-    @patch("lifetime_bot.notifications.sms.smtplib.SMTP")
+    @patch("lifetime_bot.notifications.sms.Client")
     def test_send_success(
         self,
-        mock_smtp: MagicMock,
+        mock_client_class: MagicMock,
         sms_config: SMSConfig,
-        email_config: EmailConfig,
     ) -> None:
-        """Test successful SMS send."""
-        mock_server = MagicMock()
-        mock_smtp.return_value.__enter__.return_value = mock_server
+        """Test successful SMS send via Twilio."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
 
-        service = SMSNotificationService(sms_config, email_config)
+        service = SMSNotificationService(sms_config)
         result = service.send("Test Subject", "Test Message")
 
         assert result is True
-        mock_smtp.assert_called_once_with(
-            email_config.smtp_server, email_config.smtp_port
+        mock_client_class.assert_called_once_with(
+            sms_config.account_sid, sms_config.auth_token
         )
-        mock_server.starttls.assert_called_once()
-        mock_server.login.assert_called_once()
-        mock_server.send_message.assert_called_once()
+        mock_client.messages.create.assert_called_once_with(
+            body="Test Subject: Test Message",
+            from_=sms_config.from_number,
+            to=sms_config.to_number,
+        )
 
-    @patch("lifetime_bot.notifications.sms.smtplib.SMTP")
+    @patch("lifetime_bot.notifications.sms.Client")
     def test_send_failure(
         self,
-        mock_smtp: MagicMock,
+        mock_client_class: MagicMock,
         sms_config: SMSConfig,
-        email_config: EmailConfig,
     ) -> None:
         """Test SMS send failure."""
-        mock_smtp.return_value.__enter__.side_effect = Exception("SMTP Error")
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.messages.create.side_effect = Exception("Twilio Error")
 
-        service = SMSNotificationService(sms_config, email_config)
+        service = SMSNotificationService(sms_config)
         result = service.send("Test Subject", "Test Message")
 
         assert result is False
 
-    def test_send_not_configured(self, email_config: EmailConfig) -> None:
+    def test_send_not_configured(self) -> None:
         """Test send returns False when not configured."""
-        sms_config = SMSConfig(number="", carrier="")
-        service = SMSNotificationService(sms_config, email_config)
+        sms_config = SMSConfig(
+            account_sid="",
+            auth_token="",
+            from_number="",
+            to_number="",
+        )
+        service = SMSNotificationService(sms_config)
         result = service.send("Test Subject", "Test Message")
         assert result is False
 
-    @patch("lifetime_bot.notifications.sms.smtplib.SMTP")
-    def test_send_uses_correct_gateway(
+    @patch("lifetime_bot.notifications.sms.Client")
+    def test_send_message_format(
         self,
-        mock_smtp: MagicMock,
-        email_config: EmailConfig,
+        mock_client_class: MagicMock,
+        sms_config: SMSConfig,
     ) -> None:
-        """Test SMS is sent to correct carrier gateway."""
-        mock_server = MagicMock()
-        mock_smtp.return_value.__enter__.return_value = mock_server
+        """Test SMS message is formatted correctly."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
 
-        sms_config = SMSConfig(number="5551234567", carrier="verizon")
-        service = SMSNotificationService(sms_config, email_config)
-        service.send("Test", "Message")
+        service = SMSNotificationService(sms_config)
+        service.send("Subject", "Message body")
 
-        # Verify the message was sent to the correct gateway
-        call_args = mock_server.send_message.call_args
-        msg = call_args[0][0]
-        assert msg["To"] == "5551234567@vtext.com"
+        call_args = mock_client.messages.create.call_args
+        assert call_args.kwargs["body"] == "Subject: Message body"
+        assert call_args.kwargs["from_"] == sms_config.from_number
+        assert call_args.kwargs["to"] == sms_config.to_number


### PR DESCRIPTION
AT&T deprecated their email-to-SMS gateway (mms.att.net), breaking SMS notifications. This replaces the carrier gateway approach with Twilio's SMS API.

Changes:
- Add twilio package dependency
- Update SMSConfig to use Twilio credentials (account_sid, auth_token, from_number, to_number) instead of carrier/number
- Rewrite SMSNotificationService to use Twilio SDK
- Update GitHub Actions workflow with new Twilio secrets
- Update all tests for new Twilio-based SMS config
- Update README and .env.example with Twilio setup instructions

SMS notifications now require a Twilio account with A2P 10DLC registration. Email notifications continue to work without any additional setup.