### PR TITLE
chore: update GitHub Actions to Node.js 24

### DIFF
--- a/.github/keepalive.txt
+++ b/.github/keepalive.txt
@@ -1,1 +1,1 @@
-Last keepalive: 2026-03-21 00:53:04 UTC
+Last keepalive: 2026-03-21 17:57:12 UTC

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -23,15 +23,15 @@ jobs:
         run: echo "Deploying in ${{ github.event_name == 'schedule' && 'prod' || inputs.env }}"
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Update keepalive timestamp
         run: |


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v5
- Bump `actions/setup-python` v5 → v6
- Bump `astral-sh/setup-uv` v4 → v7

Resolves Node.js 20 deprecation warning before the June 2, 2026 enforcement date.

## Test plan
- [x] Triggered bot workflow (dev) on branch — passed
- [x] Triggered keepalive workflow on branch — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)