### PR TITLE
fix: DST-aware cron schedule with 70-min buffer

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -2,7 +2,8 @@ name: Lifetime Bot Automation
 
 on:
   schedule:
-    - cron: '30 14 * * 0-4'  # Runs 30+ min before 10 AM Central (handles DST)
+    - cron: '50 13 * * 0-4'  # 8:50 AM CDT (summer, UTC-5)
+    - cron: '50 14 * * 0-4'  # 8:50 AM CST (winter, UTC-6)
   workflow_dispatch:  # Allows manual trigger
     inputs:
         env:
@@ -15,8 +16,37 @@ on:
             - prod
 
 jobs:
+  check-schedule:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    outputs:
+      should_run: ${{ steps.dst-check.outputs.should_run }}
+    steps:
+      - name: Check DST and determine correct schedule
+        id: dst-check
+        run: |
+          CURRENT_TZ=$(TZ='America/Chicago' date '+%Z')
+          CRON="${{ github.event.schedule }}"
+          echo "=== Workflow Timing ==="
+          echo "Cron trigger:       $CRON"
+          echo "Actual start (UTC): $(date -u '+%Y-%m-%d %H:%M:%S')"
+          echo "Actual start (CT):  $(TZ='America/Chicago' date '+%Y-%m-%d %H:%M:%S %Z')"
+          echo "======================"
+          if [ "$CRON" = "50 13 * * 0-4" ] && [ "$CURRENT_TZ" = "CST" ]; then
+            echo "Skipping: CDT schedule triggered during CST"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          elif [ "$CRON" = "50 14 * * 0-4" ] && [ "$CURRENT_TZ" = "CDT" ]; then
+            echo "Skipping: CST schedule triggered during CDT"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Correct schedule for $CURRENT_TZ — proceeding"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   run-bot:
     runs-on: ubuntu-latest
+    needs: check-schedule
+    if: always() && (github.event_name != 'schedule' || needs.check-schedule.outputs.should_run == 'true')
     environment: ${{ github.event_name == 'schedule' && 'prod' || inputs.env }}
     steps:
       - name: Deploying in selected environment


### PR DESCRIPTION
## Summary
- Add dual cron schedules (13:50 UTC for CDT, 14:50 UTC for CST) to ensure a consistent 1hr 10min buffer before 10 AM Central year-round
- Add `check-schedule` job that detects current DST state and skips the wrong cron — shows as "skipped" (grey) instead of failed
- Manual `workflow_dispatch` triggers bypass the check and always run

## Test plan
- [x] Tested all 4 DST/cron combinations locally — correct schedule proceeds, wrong schedule skips
- [x] Triggered workflow_dispatch on branch — `check-schedule` skipped as expected, `run-bot` proceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)