### PR TITLE
Align reservation request headers with browser

### DIFF
--- a/src/lifetime_bot/api.py
+++ b/src/lifetime_bot/api.py
@@ -50,13 +50,22 @@ class LifetimeAPIClient:
         self.session = session or requests.Session()
         headers = {
             "accept": "application/json, text/plain, */*",
+            "accept-language": "en-US,en;q=0.9",
             "content-type": "application/json",
             "ocp-apim-subscription-key": SUBSCRIPTION_KEY,
             "origin": "https://my.lifetime.life",
+            "pragma": "no-cache",
             "referer": "https://my.lifetime.life/",
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "cross-site",
+            "user-agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/147.0.0.0 Safari/537.36"
+            ),
         }
         if tokens.is_direct_auth:
-            headers["X-LTF-CT"] = tokens.jwe
             headers["X-LTF-JWE"] = tokens.jwe
             if tokens.profile:
                 headers["X-LTF-PROFILE"] = tokens.profile

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -105,6 +105,8 @@ class TestClientHeaders:
         assert headers["x-ltf-profile"] == SAMPLE_TOKENS.profile
         assert headers["x-ltf-ssoid"] == "C_abc123"
         assert headers["origin"] == "https://my.lifetime.life"
+        assert headers["accept-language"] == "en-US,en;q=0.9"
+        assert headers["user-agent"].startswith("Mozilla/5.0")
 
     def test_profile_header_is_omitted_when_unavailable(self) -> None:
         tokens = SessionTokens(
@@ -118,10 +120,10 @@ class TestClientHeaders:
         LifetimeAPIClient(tokens, session=session)
 
         headers = session.headers
-        assert headers["x-ltf-ct"] == "jwe-blob"
         assert headers["x-ltf-jwe"] == "jwe-blob"
         assert headers["x-ltf-ssoid"] == "C_abc123"
         assert "authorization" not in headers
+        assert "x-ltf-ct" not in headers
         assert "x-ltf-profile" not in headers
 
     def test_direct_auth_sessions_use_browser_style_x_ltf_headers(self) -> None:
@@ -136,11 +138,11 @@ class TestClientHeaders:
         LifetimeAPIClient(tokens, session=session)
 
         headers = session.headers
-        assert headers["x-ltf-ct"] == "direct-token"
         assert headers["x-ltf-jwe"] == "direct-token"
         assert headers["x-ltf-profile"] == "profile-jwt"
         assert headers["x-ltf-ssoid"] == "direct-sso"
         assert "authorization" not in headers
+        assert "x-ltf-ct" not in headers
 
 
 class TestListClasses:


### PR DESCRIPTION
## Summary
- align direct-auth reservation headers more closely with the working browser POST
- remove the extra `X-LTF-CT` header from direct-auth reservation requests
- keep unit coverage for the direct-auth header contract

## Validation
- `uv run pytest tests/unit tests/integration`
- live local run successfully reserved the target class again
