### PR TITLE
Separate workflow notifications from bot job

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -79,7 +79,91 @@ jobs:
           uv pip install --system -e .
 
       - name: Run Lifetime Bot
+        id: run-bot-step
+        continue-on-error: true
         run: python -u -m lifetime_bot
+        env:
+          EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
+          EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+          EMAIL_RECEIVER: ${{ secrets.EMAIL_RECEIVER }}
+          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          LIFETIME_USERNAME: ${{ secrets.LIFETIME_USERNAME }}
+          LIFETIME_PASSWORD: ${{ secrets.LIFETIME_PASSWORD }}
+          LIFETIME_CLUB_NAME: ${{ vars.LIFETIME_CLUB_NAME }}
+          RUN_ON_SCHEDULE: ${{ vars.RUN_ON_SCHEDULE }}
+          TARGET_CLASS: ${{ vars.TARGET_CLASS }}
+          TARGET_INSTRUCTOR: ${{ vars.TARGET_INSTRUCTOR }}
+          TARGET_DATE: ${{ vars.TARGET_DATE }}
+          START_TIME: ${{ vars.START_TIME }}
+          END_TIME: ${{ vars.END_TIME }}
+          NOTIFICATION_METHOD: ${{ vars.NOTIFICATION_METHOD }}
+          LIFETIME_BOT_INLINE_NOTIFICATIONS: "false"
+          LIFETIME_BOT_RESULT_PATH: ${{ runner.temp }}/lifetime-bot-result.json
+          TARGET_LOCAL_TIME: ${{ vars.TARGET_LOCAL_TIME }}
+          TIMEZONE: ${{ vars.TIMEZONE }}
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}
+          SMS_NUMBER: ${{ secrets.SMS_NUMBER }}
+
+      - name: Ensure final result payload exists
+        if: always()
+        run: |
+          if [ ! -f "$RESULT_PATH" ]; then
+            cat > "$RESULT_PATH" <<'EOF'
+            {
+              "success": false,
+              "subject": "Lifetime Bot - All Attempts Failed",
+              "body": "Failed to reserve class. The run ended before a final result payload was generated."
+            }
+            EOF
+          fi
+        env:
+          RESULT_PATH: ${{ runner.temp }}/lifetime-bot-result.json
+
+      - name: Upload bot result payload
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lifetime-bot-result
+          path: ${{ runner.temp }}/lifetime-bot-result.json
+
+      - name: Finalize bot job status
+        if: steps.run-bot-step.outcome == 'failure'
+        run: exit 1
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [check-schedule, run-bot]
+    if: always() && needs.run-bot.result != 'skipped' && (github.event_name != 'schedule' || needs.check-schedule.outputs.should_run == 'true')
+    environment: ${{ github.event_name == 'schedule' && 'prod' || inputs.env }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Install Dependencies
+        run: |
+          uv pip install --system -e .
+
+      - name: Download bot result payload
+        uses: actions/download-artifact@v4
+        with:
+          name: lifetime-bot-result
+          path: ${{ runner.temp }}
+
+      - name: Send final notification
+        run: python -m lifetime_bot.notify_result "${{ runner.temp }}/lifetime-bot-result.json"
         env:
           EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
           EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -83,11 +83,6 @@ jobs:
         continue-on-error: true
         run: python -u -m lifetime_bot
         env:
-          EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
-          EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
-          EMAIL_RECEIVER: ${{ secrets.EMAIL_RECEIVER }}
-          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
-          SMTP_PORT: ${{ secrets.SMTP_PORT }}
           LIFETIME_USERNAME: ${{ secrets.LIFETIME_USERNAME }}
           LIFETIME_PASSWORD: ${{ secrets.LIFETIME_PASSWORD }}
           LIFETIME_CLUB_NAME: ${{ vars.LIFETIME_CLUB_NAME }}
@@ -97,15 +92,10 @@ jobs:
           TARGET_DATE: ${{ vars.TARGET_DATE }}
           START_TIME: ${{ vars.START_TIME }}
           END_TIME: ${{ vars.END_TIME }}
-          NOTIFICATION_METHOD: ${{ vars.NOTIFICATION_METHOD }}
           LIFETIME_BOT_INLINE_NOTIFICATIONS: "false"
           LIFETIME_BOT_RESULT_PATH: ${{ runner.temp }}/lifetime-bot-result.json
           TARGET_LOCAL_TIME: ${{ vars.TARGET_LOCAL_TIME }}
           TIMEZONE: ${{ vars.TIMEZONE }}
-          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
-          TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}
-          SMS_NUMBER: ${{ secrets.SMS_NUMBER }}
 
       - name: Ensure final result payload exists
         if: always()
@@ -170,18 +160,9 @@ jobs:
           EMAIL_RECEIVER: ${{ secrets.EMAIL_RECEIVER }}
           SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
           SMTP_PORT: ${{ secrets.SMTP_PORT }}
-          LIFETIME_USERNAME: ${{ secrets.LIFETIME_USERNAME }}
-          LIFETIME_PASSWORD: ${{ secrets.LIFETIME_PASSWORD }}
-          LIFETIME_CLUB_NAME: ${{ vars.LIFETIME_CLUB_NAME }}
-          RUN_ON_SCHEDULE: ${{ vars.RUN_ON_SCHEDULE }}
-          TARGET_CLASS: ${{ vars.TARGET_CLASS }}
-          TARGET_INSTRUCTOR: ${{ vars.TARGET_INSTRUCTOR }}
-          TARGET_DATE: ${{ vars.TARGET_DATE }}
-          START_TIME: ${{ vars.START_TIME }}
-          END_TIME: ${{ vars.END_TIME }}
           NOTIFICATION_METHOD: ${{ vars.NOTIFICATION_METHOD }}
-          TARGET_LOCAL_TIME: ${{ vars.TARGET_LOCAL_TIME }}
-          TIMEZONE: ${{ vars.TIMEZONE }}
+          NOTIFICATION_TIMEOUT_SECONDS: ${{ vars.NOTIFICATION_TIMEOUT_SECONDS }}
+          SMTP_TIMEOUT_SECONDS: ${{ vars.SMTP_TIMEOUT_SECONDS }}
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
           TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}

--- a/src/lifetime_bot/__init__.py
+++ b/src/lifetime_bot/__init__.py
@@ -14,7 +14,7 @@ from lifetime_bot.bootstrap import (
     create_reservation_service,
 )
 from lifetime_bot.config import BotConfig, EmailConfig, SMSConfig
-from lifetime_bot.errors import LifetimeAPIError
+from lifetime_bot.errors import LifetimeAPIError, ReservationAttemptError
 from lifetime_bot.messages import describe_failure, describe_outcome, format_class_details
 from lifetime_bot.models import (
     ClassEvent,
@@ -50,6 +50,7 @@ __all__ = [
     "run_bot",
     "RetryableReservationError",
     "LifetimeAPIError",
+    "ReservationAttemptError",
     "format_class_details",
     "describe_outcome",
     "describe_failure",

--- a/src/lifetime_bot/__init__.py
+++ b/src/lifetime_bot/__init__.py
@@ -13,7 +13,7 @@ from lifetime_bot.bootstrap import (
     create_notifier,
     create_reservation_service,
 )
-from lifetime_bot.config import BotConfig, EmailConfig, SMSConfig
+from lifetime_bot.config import BotConfig, EmailConfig, NotificationConfig, SMSConfig
 from lifetime_bot.errors import LifetimeAPIError, ReservationAttemptError
 from lifetime_bot.messages import describe_failure, describe_outcome, format_class_details
 from lifetime_bot.models import (
@@ -45,6 +45,7 @@ __all__ = [
     "NotificationDispatchResult",
     "BotConfig",
     "EmailConfig",
+    "NotificationConfig",
     "SMSConfig",
     "LifetimeAPIClient",
     "run_bot",

--- a/src/lifetime_bot/bootstrap.py
+++ b/src/lifetime_bot/bootstrap.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import os
+
 from lifetime_bot.api import LifetimeAPIClient
 from lifetime_bot.auth import AuthenticatedSession, DirectAPIAuthenticator
-from lifetime_bot.config import BotConfig
+from lifetime_bot.config import BotConfig, NotificationConfig
 from lifetime_bot.notifications import EmailNotificationService, SMSNotificationService
 from lifetime_bot.notifier import NotificationCoordinator
 from lifetime_bot.orchestrator import ReservationOrchestrator
 from lifetime_bot.reservations import ReservationService
 
 HTTP_TIMEOUT_SECONDS = 10.0
-NOTIFICATION_TIMEOUT_SECONDS = 5.0
+DEFAULT_NOTIFICATION_TIMEOUT_SECONDS = 300.0
 
 
 def create_bot(config: BotConfig | None = None) -> ReservationOrchestrator:
@@ -21,7 +23,7 @@ def create_bot(config: BotConfig | None = None) -> ReservationOrchestrator:
     return ReservationOrchestrator(
         config=config,
         authenticator=DirectAPIAuthenticator(timeout=HTTP_TIMEOUT_SECONDS),
-        notifier=create_notifier(config),
+        notifier=create_notifier(config.notifications),
         reservation_service_factory=create_reservation_service,
     )
 
@@ -42,11 +44,27 @@ def create_reservation_service(authenticated: AuthenticatedSession) -> Reservati
     return ReservationService(create_api_client(authenticated))
 
 
-def create_notifier(config: BotConfig) -> NotificationCoordinator:
+def create_notifier(config: NotificationConfig) -> NotificationCoordinator:
     """Create the notification coordinator for the configured channels."""
 
     return NotificationCoordinator(
         email_service=EmailNotificationService(config.email),
         sms_service=SMSNotificationService(config.sms),
-        timeout_seconds=NOTIFICATION_TIMEOUT_SECONDS,
+        timeout_seconds=_get_timeout_seconds(
+            "NOTIFICATION_TIMEOUT_SECONDS",
+            DEFAULT_NOTIFICATION_TIMEOUT_SECONDS,
+        ),
     )
+
+
+def _get_timeout_seconds(env_name: str, default: float) -> float:
+    raw_value = os.getenv(env_name)
+    if not raw_value:
+        return default
+    try:
+        return float(raw_value)
+    except ValueError:
+        print(
+            f"Invalid {env_name} value {raw_value!r}; using default {default:.1f}s."
+        )
+        return default

--- a/src/lifetime_bot/config.py
+++ b/src/lifetime_bot/config.py
@@ -67,6 +67,26 @@ class SMSConfig:
 
 
 @dataclass
+class NotificationConfig:
+    """Notification-only configuration."""
+
+    email: EmailConfig
+    sms: SMSConfig
+    method: NotificationMethod
+
+    @classmethod
+    def from_env(cls, reload_env: bool = True) -> NotificationConfig:
+        """Create NotificationConfig from environment variables."""
+        if reload_env:
+            load_dotenv(override=True)
+        return cls(
+            email=EmailConfig.from_env(),
+            sms=SMSConfig.from_env(),
+            method=_notification_method_from_env(),
+        )
+
+
+@dataclass
 class ClassConfig:
     """Target class configuration."""
 
@@ -132,19 +152,26 @@ class BotConfig:
             # variables like PATH remain available to the process.
             load_dotenv(override=True)
 
-        notification_method = os.getenv("NOTIFICATION_METHOD", "email").lower()
-        if notification_method not in ("email", "sms", "both"):
-            notification_method = "email"
+        notification_config = NotificationConfig.from_env(reload_env=False)
 
         return cls(
             username=os.getenv("LIFETIME_USERNAME", ""),
             password=os.getenv("LIFETIME_PASSWORD", ""),
             club=ClubConfig.from_env(),
             target_class=ClassConfig.from_env(),
-            email=EmailConfig.from_env(),
-            sms=SMSConfig.from_env(),
-            notification_method=notification_method,  # type: ignore[arg-type]
+            email=notification_config.email,
+            sms=notification_config.sms,
+            notification_method=notification_config.method,
             run_on_schedule=os.getenv("RUN_ON_SCHEDULE", "false").lower() == "true",
+        )
+
+    @property
+    def notifications(self) -> NotificationConfig:
+        """Expose the notification-specific subset of the bot config."""
+        return NotificationConfig(
+            email=self.email,
+            sms=self.sms,
+            method=self.notification_method,
         )
 
 
@@ -153,3 +180,10 @@ def _normalize_instructor_filter(value: str) -> str:
     if cleaned.lower() in NO_INSTRUCTOR_VALUES:
         return ""
     return cleaned
+
+
+def _notification_method_from_env() -> NotificationMethod:
+    notification_method = os.getenv("NOTIFICATION_METHOD", "email").lower()
+    if notification_method not in ("email", "sms", "both"):
+        return "email"
+    return notification_method

--- a/src/lifetime_bot/errors.py
+++ b/src/lifetime_bot/errors.py
@@ -11,3 +11,12 @@ class LifetimeAPIError(Exception):
     @property
     def is_retryable(self) -> bool:
         return self.status_code is not None and self.status_code >= 500
+
+
+class ReservationAttemptError(Exception):
+    """Raised when a reservation attempt fails during a known phase."""
+
+    def __init__(self, phase: str, cause: BaseException) -> None:
+        super().__init__(str(cause))
+        self.phase = phase
+        self.cause = cause

--- a/src/lifetime_bot/notifications/email.py
+++ b/src/lifetime_bot/notifications/email.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -9,7 +10,7 @@ from email.mime.text import MIMEText
 from lifetime_bot.config import EmailConfig
 from lifetime_bot.notifications.base import NotificationService
 
-SMTP_TIMEOUT_SECONDS = 5.0
+DEFAULT_SMTP_TIMEOUT_SECONDS = 300.0
 
 
 class EmailNotificationService(NotificationService):
@@ -51,7 +52,7 @@ class EmailNotificationService(NotificationService):
             with smtplib.SMTP(
                 self.config.smtp_server,
                 self.config.smtp_port,
-                timeout=SMTP_TIMEOUT_SECONDS,
+                timeout=_get_smtp_timeout_seconds(),
             ) as server:
                 server.starttls()
                 server.login(self.config.sender, self.config.password)
@@ -61,3 +62,17 @@ class EmailNotificationService(NotificationService):
         except Exception as e:
             print(f"Failed to send email: {e}")
             return False
+
+
+def _get_smtp_timeout_seconds() -> float:
+    raw_value = os.getenv("SMTP_TIMEOUT_SECONDS")
+    if not raw_value:
+        return DEFAULT_SMTP_TIMEOUT_SECONDS
+    try:
+        return float(raw_value)
+    except ValueError:
+        print(
+            "Invalid SMTP_TIMEOUT_SECONDS value "
+            f"{raw_value!r}; using default {DEFAULT_SMTP_TIMEOUT_SECONDS:.1f}s."
+        )
+        return DEFAULT_SMTP_TIMEOUT_SECONDS

--- a/src/lifetime_bot/notify_result.py
+++ b/src/lifetime_bot/notify_result.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from lifetime_bot.bootstrap import create_notifier
-from lifetime_bot.config import BotConfig
+from lifetime_bot.config import NotificationConfig
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -21,9 +21,9 @@ def main(argv: list[str] | None = None) -> int:
     subject = str(payload["subject"])
     body = str(payload["body"])
 
-    config = BotConfig.from_env()
+    config = NotificationConfig.from_env()
     notifier = create_notifier(config)
-    notifier.send(subject, body, method=config.notification_method)
+    notifier.send(subject, body, method=config.method)
     return 0
 
 

--- a/src/lifetime_bot/notify_result.py
+++ b/src/lifetime_bot/notify_result.py
@@ -1,0 +1,31 @@
+"""CLI entrypoint for sending a precomputed final notification payload."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from lifetime_bot.bootstrap import create_notifier
+from lifetime_bot.config import BotConfig
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("Usage: python -m lifetime_bot.notify_result <payload.json>")
+        return 2
+
+    payload_path = Path(args[0])
+    payload = json.loads(payload_path.read_text())
+    subject = str(payload["subject"])
+    body = str(payload["body"])
+
+    config = BotConfig.from_env()
+    notifier = create_notifier(config)
+    notifier.send(subject, body, method=config.notification_method)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lifetime_bot/orchestrator.py
+++ b/src/lifetime_bot/orchestrator.py
@@ -9,7 +9,7 @@ from typing import Protocol
 
 from lifetime_bot.auth import AuthenticatedSession
 from lifetime_bot.config import BotConfig, ClassConfig, NotificationMethod
-from lifetime_bot.errors import LifetimeAPIError
+from lifetime_bot.errors import LifetimeAPIError, ReservationAttemptError
 from lifetime_bot.messages import describe_failure, describe_outcome, format_class_details
 from lifetime_bot.models import ClassEvent, RegistrationResult
 from lifetime_bot.notifier import NotificationDispatchResult
@@ -81,8 +81,8 @@ class ReservationOrchestrator:
             )
             print(f"Auth completed in {time.perf_counter() - auth_started:.2f}s.")
         except Exception as exc:
-            self._report_failure(exc, class_details, phase="login")
-            raise
+            self._log_failure(exc, phase="login")
+            raise ReservationAttemptError("login", exc) from exc
 
         reservation_service = self.reservation_service_factory(authenticated)
         try:
@@ -114,17 +114,30 @@ class ReservationOrchestrator:
                 f"{time.perf_counter() - registration_started:.2f}s."
             )
         except Exception as exc:
-            self._report_failure(exc, class_details, phase="reservation")
-            raise
+            self._log_failure(exc, phase="reservation")
+            raise ReservationAttemptError("reservation", exc) from exc
 
-        subject, body = describe_outcome(result, class_details)
+        subject, _ = describe_outcome(result, class_details)
         print(f"Reservation outcome: {subject.removeprefix('Lifetime Bot - ')}.")
         print(
             f"Reservation flow core completed in {time.perf_counter() - started:.2f}s."
         )
-        self.send_notification(subject, body)
-        print(f"Reservation flow finished in {time.perf_counter() - started:.2f}s.")
         return result
+
+    def build_outcome_notification(
+        self, result: RegistrationResult
+    ) -> tuple[str, str]:
+        class_details = self._class_details()
+        return describe_outcome(result, class_details)
+
+    def build_failure_notification(self, exc: BaseException) -> tuple[str, str]:
+        class_details = self._class_details()
+        phase = "reservation"
+        root_exc = exc
+        if isinstance(exc, ReservationAttemptError):
+            phase = exc.phase
+            root_exc = exc.cause
+        return describe_failure(root_exc, class_details=class_details, phase=phase)
 
     def send_notification(
         self, subject: str, message: str
@@ -141,11 +154,10 @@ class ReservationOrchestrator:
             self.config.target_class.date,
         )
 
-    def _report_failure(
-        self, exc: BaseException, class_details: str, *, phase: str
-    ) -> None:
+    def _class_details(self) -> str:
+        return format_class_details(self.config, self._get_target_date())
+
+    def _log_failure(self, exc: BaseException, *, phase: str) -> None:
         error_type = type(exc).__name__
         print(f"{phase.title()} failed ({error_type}): {exc}")
         print(traceback.format_exc())
-        subject, body = describe_failure(exc, class_details=class_details, phase=phase)
-        self.send_notification(subject, body)

--- a/src/lifetime_bot/runner.py
+++ b/src/lifetime_bot/runner.py
@@ -10,7 +10,7 @@ from typing import Protocol
 import requests
 
 from lifetime_bot.bootstrap import create_bot
-from lifetime_bot.errors import LifetimeAPIError
+from lifetime_bot.errors import LifetimeAPIError, ReservationAttemptError
 from lifetime_bot.models import RegistrationResult
 
 
@@ -18,6 +18,12 @@ class ReservationBot(Protocol):
     """Boundary for executing a reservation attempt."""
 
     def reserve_class(self) -> RegistrationResult: ...
+
+    def build_outcome_notification(
+        self, result: RegistrationResult
+    ) -> tuple[str, str]: ...
+
+    def build_failure_notification(self, exc: BaseException) -> tuple[str, str]: ...
 
     def send_notification(self, subject: str, message: str) -> object: ...
 
@@ -55,6 +61,7 @@ def run_bot(
             bot = bot_factory()
             result = bot.reserve_class()
             if result.is_terminal:
+                _send_outcome_notification(bot, result)
                 print(
                     f"Attempt {retry_count + 1}/{max_retries} succeeded in "
                     f"{time.perf_counter() - attempt_started:.2f}s"
@@ -78,15 +85,11 @@ def run_bot(
 
             should_retry = retry_count < max_retries and _should_retry(exc)
             if not should_retry:
-                try:
-                    if bot and hasattr(bot, "send_notification"):
-                        bot.send_notification(
-                            "Lifetime Bot - All Attempts Failed",
-                            f"Failed to reserve class after {max_retries} attempts. "
-                            f"Last error: {exc!s}",
-                        )
-                except Exception as notify_error:
-                    print(f"Could not send failure notification: {notify_error}")
+                _send_terminal_failure_notification(
+                    bot,
+                    exc,
+                    max_retries=max_retries,
+                )
                 break
             print(
                 f"Waiting {retry_delay:g} seconds before retry "
@@ -99,6 +102,8 @@ def run_bot(
 
 
 def _should_retry(exc: BaseException) -> bool:
+    if isinstance(exc, ReservationAttemptError):
+        return _should_retry(exc.cause)
     if isinstance(exc, RetryableReservationError):
         return True
     if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
@@ -106,3 +111,29 @@ def _should_retry(exc: BaseException) -> bool:
     if isinstance(exc, LifetimeAPIError):
         return exc.is_retryable
     return False
+
+
+def _send_outcome_notification(bot: ReservationBot, result: RegistrationResult) -> None:
+    try:
+        subject, body = bot.build_outcome_notification(result)
+        bot.send_notification(subject, body)
+    except Exception as notify_error:
+        print(f"Could not send outcome notification: {notify_error}")
+
+
+def _send_terminal_failure_notification(
+    bot: ReservationBot | None,
+    exc: BaseException,
+    *,
+    max_retries: int,
+) -> None:
+    if bot is None:
+        return
+    try:
+        subject, body = bot.build_failure_notification(exc)
+        summary_body = (
+            f"Failed to reserve class after {max_retries} attempts.\n\n{body}"
+        )
+        bot.send_notification("Lifetime Bot - All Attempts Failed", summary_body)
+    except Exception as notify_error:
+        print(f"Could not send failure notification: {notify_error}")

--- a/src/lifetime_bot/runner.py
+++ b/src/lifetime_bot/runner.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Protocol
 
 import requests
@@ -29,6 +31,8 @@ class ReservationBot(Protocol):
 
 
 BotFactory = Callable[[], ReservationBot]
+RESULT_PATH_ENV = "LIFETIME_BOT_RESULT_PATH"
+INLINE_NOTIFICATIONS_ENV = "LIFETIME_BOT_INLINE_NOTIFICATIONS"
 
 
 class RetryableReservationError(RuntimeError):
@@ -61,7 +65,14 @@ def run_bot(
             bot = bot_factory()
             result = bot.reserve_class()
             if result.is_terminal:
-                _send_outcome_notification(bot, result)
+                subject, body = bot.build_outcome_notification(result)
+                _record_final_result(
+                    success=True,
+                    subject=subject,
+                    body=body,
+                    outcome=result.outcome.value,
+                )
+                _send_notification(bot, subject, body, context="outcome")
                 print(
                     f"Attempt {retry_count + 1}/{max_retries} succeeded in "
                     f"{time.perf_counter() - attempt_started:.2f}s"
@@ -85,11 +96,18 @@ def run_bot(
 
             should_retry = retry_count < max_retries and _should_retry(exc)
             if not should_retry:
-                _send_terminal_failure_notification(
+                subject, body = _build_terminal_failure_notification(
                     bot,
                     exc,
                     max_retries=max_retries,
                 )
+                _record_final_result(
+                    success=False,
+                    subject=subject,
+                    body=body,
+                )
+                if bot is not None:
+                    _send_notification(bot, subject, body, context="failure")
                 break
             print(
                 f"Waiting {retry_delay:g} seconds before retry "
@@ -113,27 +131,71 @@ def _should_retry(exc: BaseException) -> bool:
     return False
 
 
-def _send_outcome_notification(bot: ReservationBot, result: RegistrationResult) -> None:
+def _send_notification(
+    bot: ReservationBot, subject: str, body: str, *, context: str
+) -> None:
+    if not _inline_notifications_enabled():
+        print(
+            f"Inline notifications disabled; skipping {context} notification send: "
+            f"{subject}"
+        )
+        return
     try:
-        subject, body = bot.build_outcome_notification(result)
         bot.send_notification(subject, body)
     except Exception as notify_error:
-        print(f"Could not send outcome notification: {notify_error}")
+        print(f"Could not send {context} notification: {notify_error}")
 
 
-def _send_terminal_failure_notification(
+def _build_terminal_failure_notification(
     bot: ReservationBot | None,
     exc: BaseException,
     *,
     max_retries: int,
-) -> None:
+) -> tuple[str, str]:
     if bot is None:
-        return
+        return (
+            "Lifetime Bot - All Attempts Failed",
+            "Failed to reserve class after "
+            f"{max_retries} attempts.\n\nError ({type(exc).__name__}): {exc!s}",
+        )
     try:
         subject, body = bot.build_failure_notification(exc)
         summary_body = (
             f"Failed to reserve class after {max_retries} attempts.\n\n{body}"
         )
-        bot.send_notification("Lifetime Bot - All Attempts Failed", summary_body)
-    except Exception as notify_error:
-        print(f"Could not send failure notification: {notify_error}")
+        return ("Lifetime Bot - All Attempts Failed", summary_body)
+    except Exception as build_error:
+        print(f"Could not build failure notification: {build_error}")
+        return (
+            "Lifetime Bot - All Attempts Failed",
+            "Failed to reserve class after "
+            f"{max_retries} attempts.\n\nError ({type(exc).__name__}): {exc!s}",
+        )
+
+
+def _inline_notifications_enabled() -> bool:
+    raw_value = os.getenv(INLINE_NOTIFICATIONS_ENV, "true").strip().lower()
+    return raw_value not in {"0", "false", "no", "off"}
+
+
+def _record_final_result(
+    *,
+    success: bool,
+    subject: str,
+    body: str,
+    outcome: str | None = None,
+) -> None:
+    result_path = os.getenv(RESULT_PATH_ENV, "").strip()
+    if not result_path:
+        return
+    payload: dict[str, object] = {
+        "success": success,
+        "subject": subject,
+        "body": body,
+    }
+    if outcome is not None:
+        payload["outcome"] = outcome
+    path = Path(result_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote final result payload to {path}.")

--- a/tests/integration/test_config_integration.py
+++ b/tests/integration/test_config_integration.py
@@ -55,7 +55,6 @@ class TestBotConfigIntegration:
             "LIFETIME_USERNAME": "user@example.com",
             "LIFETIME_PASSWORD": "password",
             "LIFETIME_CLUB_NAME": "Test Club",
-            "LIFETIME_CLUB_STATE": "CA",
             "RUN_ON_SCHEDULE": "true",
         }
         with patch.dict(os.environ, env, clear=True):
@@ -69,7 +68,6 @@ class TestBotConfigIntegration:
             "LIFETIME_USERNAME": "user@example.com",
             "LIFETIME_PASSWORD": "password",
             "LIFETIME_CLUB_NAME": "Test Club",
-            "LIFETIME_CLUB_STATE": "CA",
             "NOTIFICATION_METHOD": "sms",
             "TWILIO_ACCOUNT_SID": "ACtest123",
             "TWILIO_AUTH_TOKEN": "authtoken123",

--- a/tests/integration/test_notifications_integration.py
+++ b/tests/integration/test_notifications_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 from lifetime_bot.config import EmailConfig, SMSConfig
@@ -9,6 +10,7 @@ from lifetime_bot.notifications import (
     EmailNotificationService,
     SMSNotificationService,
 )
+from lifetime_bot.notifications.email import DEFAULT_SMTP_TIMEOUT_SECONDS
 
 
 class TestEmailNotificationIntegration:
@@ -40,7 +42,7 @@ class TestEmailNotificationIntegration:
         mock_smtp.assert_called_once_with(
             email_config.smtp_server,
             email_config.smtp_port,
-            timeout=5.0,
+            timeout=DEFAULT_SMTP_TIMEOUT_SECONDS,
         )
         mock_server.starttls.assert_called_once()
         mock_server.login.assert_called_once_with(
@@ -137,6 +139,24 @@ class TestSMSNotificationIntegration:
 
 class TestNotificationServiceInteraction:
     """Integration tests for notification service interaction patterns."""
+
+    @patch("lifetime_bot.notifications.email.smtplib.SMTP")
+    def test_email_service_honors_timeout_override(
+        self, mock_smtp: MagicMock, email_config: EmailConfig
+    ) -> None:
+        mock_server = MagicMock()
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        with patch.dict(os.environ, {"SMTP_TIMEOUT_SECONDS": "90"}, clear=False):
+            service = EmailNotificationService(email_config)
+            result = service.send("Test Notification", "Body")
+
+        assert result is True
+        mock_smtp.assert_called_once_with(
+            email_config.smtp_server,
+            email_config.smtp_port,
+            timeout=90.0,
+        )
 
     @patch("lifetime_bot.notifications.email.smtplib.SMTP")
     def test_email_service_can_send_independently(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,6 +12,7 @@ from lifetime_bot.config import (
     ClassConfig,
     ClubConfig,
     EmailConfig,
+    NotificationConfig,
     SMSConfig,
 )
 
@@ -241,7 +242,6 @@ class TestBotConfig:
             "LIFETIME_USERNAME": "test@example.com",
             "LIFETIME_PASSWORD": "testpassword",
             "LIFETIME_CLUB_NAME": "Test Club",
-            "LIFETIME_CLUB_STATE": "TX",
             "NOTIFICATION_METHOD": "invalid",
         }
         with patch.dict(os.environ, env, clear=True):
@@ -254,7 +254,6 @@ class TestBotConfig:
             "LIFETIME_USERNAME": "test@example.com",
             "LIFETIME_PASSWORD": "testpassword",
             "LIFETIME_CLUB_NAME": "Test Club",
-            "LIFETIME_CLUB_STATE": "TX",
             "NOTIFICATION_METHOD": "both",
         }
         with patch.dict(os.environ, env, clear=True):
@@ -267,9 +266,31 @@ class TestBotConfig:
             "LIFETIME_USERNAME": "test@example.com",
             "LIFETIME_PASSWORD": "testpassword",
             "LIFETIME_CLUB_NAME": "Test Club",
-            "LIFETIME_CLUB_STATE": "TX",
             "RUN_ON_SCHEDULE": "true",
         }
         with patch.dict(os.environ, env, clear=True):
             config = BotConfig.from_env(reload_env=False)
             assert config.run_on_schedule is True
+
+    def test_exposes_notification_subset(self, bot_config: BotConfig) -> None:
+        notification_config = bot_config.notifications
+
+        assert notification_config.email is bot_config.email
+        assert notification_config.sms is bot_config.sms
+        assert notification_config.method == bot_config.notification_method
+
+
+class TestNotificationConfig:
+    def test_from_env(self, mock_env: dict[str, str]) -> None:
+        assert mock_env
+        config = NotificationConfig.from_env(reload_env=False)
+
+        assert config.email.sender == "test@gmail.com"
+        assert config.sms.account_sid == "ACtest123456789"
+        assert config.method == "email"
+
+    def test_invalid_notification_method_defaults_to_email(self) -> None:
+        env = {"NOTIFICATION_METHOD": "invalid"}
+        with patch.dict(os.environ, env, clear=True):
+            config = NotificationConfig.from_env(reload_env=False)
+            assert config.method == "email"

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from lifetime_bot.notifications import (
     NotificationService,
     SMSNotificationService,
 )
+from lifetime_bot.notifications.email import DEFAULT_SMTP_TIMEOUT_SECONDS
 
 
 class TestNotificationService:
@@ -57,13 +59,31 @@ class TestEmailNotificationService:
         mock_smtp.assert_called_once_with(
             email_config.smtp_server,
             email_config.smtp_port,
-            timeout=5.0,
+            timeout=DEFAULT_SMTP_TIMEOUT_SECONDS,
         )
         mock_server.starttls.assert_called_once()
         mock_server.login.assert_called_once_with(
             email_config.sender, email_config.password
         )
         mock_server.send_message.assert_called_once()
+
+    @patch("lifetime_bot.notifications.email.smtplib.SMTP")
+    def test_send_uses_smtp_timeout_override(
+        self, mock_smtp: MagicMock, email_config: EmailConfig
+    ) -> None:
+        mock_server = MagicMock()
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        service = EmailNotificationService(email_config)
+        with patch.dict(os.environ, {"SMTP_TIMEOUT_SECONDS": "42.5"}, clear=False):
+            result = service.send("Test Subject", "Test Message")
+
+        assert result is True
+        mock_smtp.assert_called_once_with(
+            email_config.smtp_server,
+            email_config.smtp_port,
+            timeout=42.5,
+        )
 
     @patch("lifetime_bot.notifications.email.smtplib.SMTP")
     def test_send_failure(

--- a/tests/unit/test_notify_result.py
+++ b/tests/unit/test_notify_result.py
@@ -1,0 +1,47 @@
+"""Unit tests for the final-result notification CLI."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from lifetime_bot.notify_result import main
+
+
+class TestNotifyResult:
+    def test_sends_payload_through_configured_notifier(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        payload_path = tmp_path / "result.json"
+        payload_path.write_text(
+            json.dumps(
+                {
+                    "subject": "Lifetime Bot - Reserved",
+                    "body": "reserved body",
+                    "success": True,
+                }
+            )
+        )
+        config = MagicMock()
+        config.notification_method = "email"
+        notifier = MagicMock()
+
+        monkeypatch.setattr(
+            "lifetime_bot.notify_result.BotConfig.from_env",
+            MagicMock(return_value=config),
+        )
+        monkeypatch.setattr(
+            "lifetime_bot.notify_result.create_notifier",
+            MagicMock(return_value=notifier),
+        )
+
+        assert main([str(payload_path)]) == 0
+
+        notifier.send.assert_called_once_with(
+            "Lifetime Bot - Reserved",
+            "reserved body",
+            method="email",
+        )
+
+    def test_returns_usage_error_without_path(self) -> None:
+        assert main([]) == 2

--- a/tests/unit/test_notify_result.py
+++ b/tests/unit/test_notify_result.py
@@ -20,14 +20,14 @@ class TestNotifyResult:
                     "body": "reserved body",
                     "success": True,
                 }
-            )
+        )
         )
         config = MagicMock()
-        config.notification_method = "email"
+        config.method = "email"
         notifier = MagicMock()
 
         monkeypatch.setattr(
-            "lifetime_bot.notify_result.BotConfig.from_env",
+            "lifetime_bot.notify_result.NotificationConfig.from_env",
             MagicMock(return_value=config),
         )
         monkeypatch.setattr(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -12,7 +12,7 @@ import pytest
 
 from lifetime_bot.auth import AuthenticatedSession
 from lifetime_bot.config import BotConfig
-from lifetime_bot.errors import LifetimeAPIError
+from lifetime_bot.errors import LifetimeAPIError, ReservationAttemptError
 from lifetime_bot.models import RegistrationOutcome, RegistrationResult, SessionTokens
 from lifetime_bot.notifier import NotificationDispatchResult
 from lifetime_bot.orchestrator import ReservationOrchestrator
@@ -151,8 +151,7 @@ class TestReserveClass:
             target_date="2026-04-29",
         )
         harness.reservation_service.reserve_event.assert_called_once_with("ZXhlcnA6ZXZ0")
-        harness.notifier.send.assert_called_once()
-        assert harness.notifier.send.call_args.args[0] == "Lifetime Bot - Reserved"
+        harness.notifier.send.assert_not_called()
 
     def test_logs_reservation_outcome_before_notification_phase(
         self,
@@ -179,27 +178,59 @@ class TestReserveClass:
         captured = capsys.readouterr().out
         assert "Reservation outcome: Reserved." in captured
         assert captured.index("Reservation outcome: Reserved.") < captured.index(
-            "Reservation flow finished"
+            "Reservation flow core completed"
         )
 
 
 class TestReserveClassFailures:
-    def test_notifies_on_login_failure(self, harness: BotHarness) -> None:
+    def test_wraps_login_failure_without_notifying(self, harness: BotHarness) -> None:
         harness.authenticator.login.side_effect = RuntimeError("login broke")
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ReservationAttemptError, match="login broke") as exc_info:
             harness.bot.reserve_class()
 
-        harness.notifier.send.assert_called_once()
-        assert harness.notifier.send.call_args.args[0] == "Lifetime Bot - Login Failed"
+        assert exc_info.value.phase == "login"
+        assert isinstance(exc_info.value.cause, RuntimeError)
+        harness.notifier.send.assert_not_called()
 
-    def test_notifies_on_missing_class(self, harness: BotHarness) -> None:
+    def test_wraps_missing_class_failure_without_notifying(
+        self, harness: BotHarness
+    ) -> None:
         harness.reservation_service.find_target_event.return_value = None
         harness.bot.config.target_class.date = "2026-04-29"
         harness.bot.config.run_on_schedule = False
 
-        with pytest.raises(LifetimeAPIError):
+        with pytest.raises(ReservationAttemptError) as exc_info:
             harness.bot.reserve_class()
 
         harness.reservation_service.reserve_event.assert_not_called()
-        assert harness.notifier.send.call_args.args[0] == "Lifetime Bot - Failure"
+        assert exc_info.value.phase == "reservation"
+        assert isinstance(exc_info.value.cause, LifetimeAPIError)
+        harness.notifier.send.assert_not_called()
+
+    def test_builds_outcome_notification(self, harness: BotHarness) -> None:
+        harness.bot.config.target_class.date = "2026-04-29"
+        harness.bot.config.run_on_schedule = False
+
+        subject, body = harness.bot.build_outcome_notification(
+            _result(RegistrationOutcome.RESERVED, raw_status="reserved")
+        )
+
+        assert subject == "Lifetime Bot - Reserved"
+        assert "Your class was successfully reserved!" in body
+
+    def test_builds_failure_notification_from_wrapped_error(
+        self, harness: BotHarness
+    ) -> None:
+        harness.bot.config.target_class.date = "2026-04-29"
+        harness.bot.config.run_on_schedule = False
+
+        subject, body = harness.bot.build_failure_notification(
+            ReservationAttemptError(
+                "login",
+                RuntimeError("login broke"),
+            )
+        )
+
+        assert subject == "Lifetime Bot - Login Failed"
+        assert "Error (RuntimeError): login broke" in body

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -26,6 +26,10 @@ class TestRunBot:
     def test_stops_after_first_success(self) -> None:
         bot = MagicMock()
         bot.reserve_class.return_value = _result(RegistrationOutcome.RESERVED)
+        bot.build_outcome_notification.return_value = (
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
 
         assert (
             runner.run_bot(
@@ -36,13 +40,20 @@ class TestRunBot:
         )
 
         bot.reserve_class.assert_called_once_with()
-        bot.send_notification.assert_not_called()
+        bot.send_notification.assert_called_once_with(
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
 
     def test_retries_after_failure_then_succeeds(self) -> None:
         first = MagicMock()
         first.reserve_class.side_effect = requests.Timeout("boom")
         second = MagicMock()
         second.reserve_class.return_value = _result(RegistrationOutcome.RESERVED)
+        second.build_outcome_notification.return_value = (
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
         bots = iter([first, second])
         sleep = MagicMock()
 
@@ -59,6 +70,11 @@ class TestRunBot:
         assert first.reserve_class.call_count == 1
         assert second.reserve_class.call_count == 1
         sleep.assert_called_once_with(5.0)
+        first.send_notification.assert_not_called()
+        second.send_notification.assert_called_once_with(
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
 
     def test_non_terminal_result_is_treated_as_failure_and_retried(self) -> None:
         first = MagicMock()
@@ -67,6 +83,10 @@ class TestRunBot:
         )
         second = MagicMock()
         second.reserve_class.return_value = _result(RegistrationOutcome.RESERVED)
+        second.build_outcome_notification.return_value = (
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
         bots = iter([first, second])
         sleep = MagicMock()
 
@@ -83,12 +103,21 @@ class TestRunBot:
         assert first.reserve_class.call_count == 1
         assert second.reserve_class.call_count == 1
         sleep.assert_called_once_with(2.0)
+        first.send_notification.assert_not_called()
+        second.send_notification.assert_called_once_with(
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
 
     def test_sends_terminal_notification_after_all_failures(self) -> None:
         first = MagicMock()
         first.reserve_class.side_effect = requests.Timeout("boom")
         second = MagicMock()
         second.reserve_class.side_effect = requests.Timeout("still boom")
+        second.build_failure_notification.return_value = (
+            "Lifetime Bot - Failure",
+            "failure body",
+        )
         bots = iter([first, second])
         sleep = MagicMock()
 
@@ -103,15 +132,20 @@ class TestRunBot:
         )
 
         sleep.assert_called_once_with(1.0)
+        first.send_notification.assert_not_called()
         second.send_notification.assert_called_once()
         subject, body = second.send_notification.call_args.args
         assert subject == "Lifetime Bot - All Attempts Failed"
-        assert "still boom" in body
+        assert body == "Failed to reserve class after 2 attempts.\n\nfailure body"
 
     def test_does_not_retry_non_retryable_api_errors(self) -> None:
         bot = MagicMock()
         bot.reserve_class.side_effect = LifetimeAPIError(
             "bad target date", status_code=400
+        )
+        bot.build_failure_notification.return_value = (
+            "Lifetime Bot - Failure",
+            "failure body",
         )
         sleep = MagicMock()
 
@@ -127,4 +161,7 @@ class TestRunBot:
 
         bot.reserve_class.assert_called_once_with()
         sleep.assert_not_called()
-        bot.send_notification.assert_called_once()
+        bot.send_notification.assert_called_once_with(
+            "Lifetime Bot - All Attempts Failed",
+            "Failed to reserve class after 3 attempts.\n\nfailure body",
+        )

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import requests
@@ -165,3 +166,67 @@ class TestRunBot:
             "Lifetime Bot - All Attempts Failed",
             "Failed to reserve class after 3 attempts.\n\nfailure body",
         )
+
+    def test_writes_success_result_payload(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        bot = MagicMock()
+        bot.reserve_class.return_value = _result(RegistrationOutcome.RESERVED)
+        bot.build_outcome_notification.return_value = (
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
+        result_path = tmp_path / "result.json"
+        monkeypatch.setenv(runner.RESULT_PATH_ENV, str(result_path))
+
+        assert runner.run_bot(bot_factory=lambda: bot, max_retries=1) is True
+
+        payload = json.loads(result_path.read_text())
+        assert payload == {
+            "body": "reserved body",
+            "outcome": "reserved",
+            "subject": "Lifetime Bot - Reserved",
+            "success": True,
+        }
+
+    def test_skips_inline_notifications_when_disabled(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        bot = MagicMock()
+        bot.reserve_class.return_value = _result(RegistrationOutcome.RESERVED)
+        bot.build_outcome_notification.return_value = (
+            "Lifetime Bot - Reserved",
+            "reserved body",
+        )
+        result_path = tmp_path / "result.json"
+        monkeypatch.setenv(runner.RESULT_PATH_ENV, str(result_path))
+        monkeypatch.setenv(runner.INLINE_NOTIFICATIONS_ENV, "false")
+
+        assert runner.run_bot(bot_factory=lambda: bot, max_retries=1) is True
+
+        bot.send_notification.assert_not_called()
+        payload = json.loads(result_path.read_text())
+        assert payload["subject"] == "Lifetime Bot - Reserved"
+
+    def test_writes_failure_result_payload_when_notifications_disabled(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        bot = MagicMock()
+        bot.reserve_class.side_effect = LifetimeAPIError("boom", status_code=500)
+        bot.build_failure_notification.return_value = (
+            "Lifetime Bot - Failure",
+            "failure body",
+        )
+        result_path = tmp_path / "result.json"
+        monkeypatch.setenv(runner.RESULT_PATH_ENV, str(result_path))
+        monkeypatch.setenv(runner.INLINE_NOTIFICATIONS_ENV, "false")
+
+        assert runner.run_bot(bot_factory=lambda: bot, max_retries=1) is False
+
+        bot.send_notification.assert_not_called()
+        payload = json.loads(result_path.read_text())
+        assert payload == {
+            "body": "Failed to reserve class after 1 attempts.\n\nfailure body",
+            "subject": "Lifetime Bot - All Attempts Failed",
+            "success": False,
+        }


### PR DESCRIPTION
## Summary
- move notifications to a separate workflow job that runs after the bot job
- have run-bot write a final result payload instead of sending notifications inline
- split notification-only config from bot config and raise notification/SMTP timeouts to 5 minutes

## Verification
- uv run pytest tests/unit tests/integration
- uv run ruff check src tests