### PR TITLE
Handle pending ALPHA reservation completion

### DIFF
--- a/src/lifetime_bot/models.py
+++ b/src/lifetime_bot/models.py
@@ -122,13 +122,3 @@ class RegistrationResult:
             required_documents=None,
             raw=raw,
         )
-
-    def completed(self) -> RegistrationResult:
-        return RegistrationResult(
-            registration_id=self.registration_id,
-            outcome=RegistrationOutcome.RESERVED,
-            raw_status="complete",
-            needs_complete=False,
-            required_documents=self.required_documents,
-            raw=self.raw,
-        )

--- a/src/lifetime_bot/reservations.py
+++ b/src/lifetime_bot/reservations.py
@@ -92,24 +92,33 @@ class ReservationService:
                 )
 
         if result.needs_complete:
+            pending_result = result
             documents = result.required_documents
             if documents is None:
                 documents = self.fetch_required_documents(event_id)
+            accepted_documents = list(documents or [])
             if documents is None:
                 _log_payload(
                     "POST /event completion payload lacked recognized waiver/document ids",
                     result.raw,
                 )
-                raise LifetimeAPIError(
-                    "Registration requires completion, but no waiver/document ids "
-                    "were available."
+                print(
+                    "No waiver/document ids were exposed; attempting PUT /complete "
+                    "with accepted documents: []."
                 )
-            accepted_documents = list(documents)
             self.client.complete_registration(
                 result.registration_id,
                 accepted_documents=accepted_documents,
             )
-            result = result.completed()
+            verified = self.detect_existing_registration(
+                event_id, context="post-complete"
+            )
+            if verified is None:
+                raise LifetimeAPIError(
+                    "PUT /complete succeeded, but follow-up registration info did "
+                    "not confirm a reserved or waitlisted outcome."
+                )
+            result = _resolve_post_complete_result(pending_result, verified)
             print(
                 f"PUT /complete succeeded "
                 f"(accepted documents: {accepted_documents})."
@@ -162,6 +171,28 @@ class ReservationService:
             return None
 
         member_name = str(member.get("name") or "Current member")
+        if _is_waitlisted_member(member):
+            waitlist_position = _waitlist_position(member)
+            if waitlist_position is not None:
+                print(
+                    f"Registration info ({context}) shows {member_name} "
+                    f"({self.client.member_id}) is on the waitlist at position "
+                    f"{waitlist_position} for event {event_id}."
+                )
+            else:
+                print(
+                    f"Registration info ({context}) shows {member_name} "
+                    f"({self.client.member_id}) is on the waitlist for event "
+                    f"{event_id}."
+                )
+            return RegistrationResult(
+                registration_id=None,
+                outcome=RegistrationOutcome.WAITLISTED,
+                raw_status="waitlisted",
+                needs_complete=False,
+                required_documents=None,
+                raw=info,
+            )
         print(
             f"Registration info ({context}) shows {member_name} "
             f"({self.client.member_id}) is already reserved for event {event_id}."
@@ -188,9 +219,56 @@ def _find_registered_member(
     return None
 
 
+def _is_waitlisted_member(member: dict[str, Any]) -> bool:
+    if _waitlist_position(member) is not None:
+        return True
+    cancel_ctas = member.get("cancelCtas")
+    if not isinstance(cancel_ctas, list):
+        return False
+    for cta in cancel_ctas:
+        if not isinstance(cta, dict):
+            continue
+        text = str(cta.get("text") or "").lower()
+        if "waitlist" in text:
+            return True
+    return False
+
+
+def _waitlist_position(member: dict[str, Any]) -> int | None:
+    position = member.get("spotWaitlist")
+    if isinstance(position, int):
+        return position
+    if isinstance(position, str) and position.isdigit():
+        return int(position)
+    return None
+
+
 def _log_payload(label: str, payload: Any) -> None:
     try:
         rendered = json.dumps(payload, sort_keys=True, default=str)
     except TypeError:
         rendered = repr(payload)
     print(f"{label}: {rendered}")
+
+
+def _resolve_post_complete_result(
+    pending_result: RegistrationResult,
+    verified_result: RegistrationResult,
+) -> RegistrationResult:
+    if verified_result.outcome is RegistrationOutcome.WAITLISTED:
+        return RegistrationResult(
+            registration_id=pending_result.registration_id,
+            outcome=RegistrationOutcome.WAITLISTED,
+            raw_status=verified_result.raw_status,
+            needs_complete=False,
+            required_documents=pending_result.required_documents,
+            raw=verified_result.raw,
+        )
+    return RegistrationResult(
+        registration_id=pending_result.registration_id,
+        outcome=RegistrationOutcome.RESERVED,
+        raw_status="complete",
+        needs_complete=False,
+        required_documents=pending_result.required_documents,
+        raw=verified_result.raw,
+    )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -387,6 +387,23 @@ class TestRegister:
         assert result.needs_complete is True
         assert result.required_documents == (77,)
 
+    def test_parses_pending_waitlist_like_response(self) -> None:
+        payload = {
+            "regId": 186195720,
+            "regStatus": "pending",
+            "hasWaitlist": True,
+            "hasSpots": False,
+            "openSpots": 0,
+            "totalWaitlisted": 13,
+        }
+        client, _ = _client_with_mock(_FakeResponse(payload=payload))
+
+        result = client.register("evt")
+
+        assert result.outcome is RegistrationOutcome.PENDING_COMPLETION
+        assert result.was_waitlisted is False
+        assert result.needs_complete is True
+
     def test_raises_when_response_missing_id(self) -> None:
         client, _ = _client_with_mock(_FakeResponse(payload={"status": "reserved"}))
         with pytest.raises(LifetimeAPIError):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -70,6 +70,23 @@ class TestParseRegistrationResult:
         assert result.raw_status == "pending"
         assert result.required_documents == (77,)
 
+    def test_parses_pending_full_waitlist_registration_as_pending_completion(self) -> None:
+        payload = {
+            "regId": 186195720,
+            "regStatus": "pending",
+            "hasWaitlist": True,
+            "hasSpots": False,
+            "openSpots": 0,
+            "totalWaitlisted": 13,
+        }
+
+        result = parse_registration_result(payload)
+
+        assert result.outcome is RegistrationOutcome.PENDING_COMPLETION
+        assert result.raw_status == "pending"
+        assert result.needs_complete is True
+        assert result.required_documents is None
+
     def test_raises_when_response_missing_id(self) -> None:
         with pytest.raises(LifetimeAPIError):
             parse_registration_result({"status": "reserved"})

--- a/tests/unit/test_reservations.py
+++ b/tests/unit/test_reservations.py
@@ -153,9 +153,11 @@ class TestReservationServiceReserveEvent:
 
     def test_fetches_required_documents_when_register_omits_them(self) -> None:
         client = MagicMock()
+        client.member_id = 110137193
         client.get_registration_info.side_effect = [
             LifetimeAPIError("not found", status_code=404),
             {"agreement": {"agreementId": 77}},
+            {"registeredMembers": [{"id": 110137193, "name": "Tyler"}]},
         ]
         client.register.return_value = RegistrationResult(
             registration_id=101,
@@ -169,8 +171,68 @@ class TestReservationServiceReserveEvent:
         result = ReservationService(client).reserve_event("evt")
 
         assert result.outcome is RegistrationOutcome.RESERVED
+        assert result.registration_id == 101
         client.complete_registration.assert_called_once_with(
             101, accepted_documents=[77]
+        )
+
+    def test_returns_waitlisted_result_without_completion(self) -> None:
+        client = MagicMock()
+        client.get_registration_info.side_effect = LifetimeAPIError(
+            "not found",
+            status_code=404,
+        )
+        client.register.return_value = RegistrationResult(
+            registration_id=101,
+            outcome=RegistrationOutcome.WAITLISTED,
+            raw_status="pending",
+            needs_complete=False,
+            required_documents=None,
+            raw={},
+        )
+
+        result = ReservationService(client).reserve_event("evt")
+
+        assert result.outcome is RegistrationOutcome.WAITLISTED
+        client.complete_registration.assert_not_called()
+
+    def test_completes_pending_waitlist_flow_with_empty_documents(self) -> None:
+        client = MagicMock()
+        client.member_id = 110137193
+        client.get_registration_info.side_effect = [
+            LifetimeAPIError("not found", status_code=404),
+            {
+                "registeredMembers": [],
+                "unregisteredMembers": [{"id": 110137193, "name": "Tyler"}],
+            },
+            {
+                "registeredMembers": [
+                    {
+                        "id": 110137193,
+                        "name": "Tyler",
+                        "spotWaitlist": 13,
+                        "cancelCtas": [{"text": "Leave Waitlist"}],
+                    }
+                ],
+                "unregisteredMembers": [],
+            },
+        ]
+        client.register.return_value = RegistrationResult(
+            registration_id=101,
+            outcome=RegistrationOutcome.PENDING_COMPLETION,
+            raw_status="pending",
+            needs_complete=True,
+            required_documents=None,
+            raw={"regId": 101, "regStatus": "pending"},
+        )
+
+        result = ReservationService(client).reserve_event("evt")
+
+        assert result.outcome is RegistrationOutcome.WAITLISTED
+        assert result.registration_id == 101
+        client.complete_registration.assert_called_once_with(
+            101,
+            accepted_documents=[],
         )
 
     def test_skips_post_when_already_reserved(self) -> None:
@@ -225,9 +287,11 @@ class TestReservationServiceReserveEvent:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         client = MagicMock()
+        client.member_id = 110137193
         client.get_registration_info.side_effect = [
             LifetimeAPIError("not found", status_code=404),
             {"registeredMembers": [], "unregisteredMembers": [{"agreementId": 77}]},
+            {"registeredMembers": [], "unregisteredMembers": [{"id": 110137193}]},
         ]
         client.register.return_value = RegistrationResult(
             registration_id=101,
@@ -238,10 +302,16 @@ class TestReservationServiceReserveEvent:
             raw={"regId": 101, "regStatus": "pending"},
         )
 
-        with pytest.raises(LifetimeAPIError, match="no waiver/document ids"):
+        with pytest.raises(
+            LifetimeAPIError,
+            match="did not confirm a reserved or waitlisted outcome",
+        ):
             ReservationService(client).reserve_event("evt")
 
-        client.complete_registration.assert_not_called()
+        client.complete_registration.assert_called_once_with(
+            101,
+            accepted_documents=[],
+        )
         captured = capsys.readouterr().out
         assert (
             "Registration info payload lacked recognized waiver/document ids: "


### PR DESCRIPTION
## Summary
- handle ALPHA-style pending registrations by calling PUT /complete even when no document ids are exposed
- verify post-complete state to distinguish real waitlist vs real reservation outcomes
- preserve fresh post-complete reservations as Reserved instead of relabeling them as Already Reserved
- remove the last stale registration helper discovered in the dead-code sweep

## Verification
- uv run pytest tests/unit/test_parsers.py tests/unit/test_api.py tests/unit/test_reservations.py tests/unit/test_messages.py tests/unit/test_orchestrator.py tests/unit/test_runner.py
- uv run ruff check src tests
- live local runs for both a full ALPHA class and an open ALPHA class
