### PR TITLE
Refine scheduled workflow labels and fallbacks

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -2,18 +2,31 @@ name: Life Time Reservation Bot
 run-name: >-
   ${{
     github.event_name == 'schedule'
-    && format('schedule {0}', github.event.schedule)
+    && (
+      github.event.schedule == '17 7 * * 0-4' && 'Scheduled (CT primary)'
+      || github.event.schedule == '37 7 * * 0-4' && 'Scheduled (CT backup 1)'
+      || github.event.schedule == '17 8 * * 0-4' && 'Scheduled (CT backup 2)'
+      || github.event.schedule == '37 8 * * 0-4' && 'Scheduled (CT backup 3)'
+      || github.event.schedule == '17 9 * * 0-4' && 'Scheduled (CT final backup)'
+      || format('Scheduled ({0})', github.event.schedule)
+    )
     || github.event_name == 'workflow_dispatch'
-    && format('manual {0} on {1}', inputs.env, inputs.runner)
+    && format('Manual ({0}, {1})', inputs.env, inputs.runner)
     || github.event_name
   }}
 
 on:
   schedule:
-    - cron: '17 12 * * 0-4'  # 7:17 AM CDT (summer, UTC-5) — 2h43m buffer before 10 AM CT target
-    - cron: '37 12 * * 0-4'  # 7:37 AM CDT backup — 2h23m buffer before 10 AM CT target
-    - cron: '17 13 * * 0-4'  # 7:17 AM CST (winter, UTC-6) — 2h43m buffer before 10 AM CT target
-    - cron: '37 13 * * 0-4'  # 7:37 AM CST backup — 2h23m buffer before 10 AM CT target
+    - cron: '17 7 * * 0-4'   # 7:17 AM CT primary — 2h43m buffer before 10 AM CT target
+      timezone: 'America/Chicago'
+    - cron: '37 7 * * 0-4'   # 7:37 AM CT backup 1 — 2h23m buffer before 10 AM CT target
+      timezone: 'America/Chicago'
+    - cron: '17 8 * * 0-4'   # 8:17 AM CT backup 2 — 1h43m buffer before 10 AM CT target
+      timezone: 'America/Chicago'
+    - cron: '37 8 * * 0-4'   # 8:37 AM CT backup 3 — 1h23m buffer before 10 AM CT target
+      timezone: 'America/Chicago'
+    - cron: '17 9 * * 0-4'   # 9:17 AM CT final backup — 43m buffer before 10 AM CT target
+      timezone: 'America/Chicago'
   workflow_dispatch:  # Allows manual trigger
     inputs:
         env:
@@ -41,12 +54,11 @@ jobs:
     permissions:
       actions: read
     outputs:
-      should_run: ${{ steps.schedule-decision.outputs.should_run }}
+      should_run: ${{ steps.duplicate-check.outputs.should_run }}
     steps:
-      - name: Check DST and determine correct schedule
-        id: dst-check
+      - name: Log workflow timing
+        id: schedule-timing
         run: |
-          CURRENT_TZ=$(TZ='America/Chicago' date '+%Z')
           CURRENT_LOCAL_DATE=$(TZ='America/Chicago' date '+%Y-%m-%d')
           CRON="${{ github.event.schedule }}"
           echo "=== Workflow Timing ==="
@@ -54,51 +66,17 @@ jobs:
           echo "Actual start (UTC): $(date -u '+%Y-%m-%d %H:%M:%S')"
           echo "Actual start (CT):  $(TZ='America/Chicago' date '+%Y-%m-%d %H:%M:%S %Z')"
           echo "======================"
-          echo "current_tz=$CURRENT_TZ" >> "$GITHUB_OUTPUT"
           echo "current_local_date=$CURRENT_LOCAL_DATE" >> "$GITHUB_OUTPUT"
-
-          if [ "$CURRENT_TZ" = "CST" ] && { [ "$CRON" = "17 12 * * 0-4" ] || [ "$CRON" = "37 12 * * 0-4" ]; }; then
-            echo "Skipping: CDT schedule triggered during CST"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-          elif [ "$CURRENT_TZ" = "CDT" ] && { [ "$CRON" = "17 13 * * 0-4" ] || [ "$CRON" = "37 13 * * 0-4" ]; }; then
-            echo "Skipping: CST schedule triggered during CDT"
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Correct schedule for $CURRENT_TZ — proceeding"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Skip duplicate scheduled run for the active Chicago day
         id: duplicate-check
-        if: steps.dst-check.outputs.should_run == 'true'
         uses: actions/github-script@v8
         env:
-          CURRENT_TZ: ${{ steps.dst-check.outputs.current_tz }}
-          CURRENT_LOCAL_DATE: ${{ steps.dst-check.outputs.current_local_date }}
+          CURRENT_LOCAL_DATE: ${{ steps.schedule-timing.outputs.current_local_date }}
         with:
           script: |
             const runId = Number(process.env.GITHUB_RUN_ID);
-            const currentTz = process.env.CURRENT_TZ;
             const currentLocalDate = process.env.CURRENT_LOCAL_DATE;
-            const activeTitlesByTz = {
-              CDT: [
-                "schedule 17 12 * * 0-4",
-                "schedule 37 12 * * 0-4",
-              ],
-              CST: [
-                "schedule 17 13 * * 0-4",
-                "schedule 37 13 * * 0-4",
-              ],
-            };
-            const activeTitles = activeTitlesByTz[currentTz] ?? [];
-
-            if (activeTitles.length === 0) {
-              core.warning(
-                `Unrecognized Chicago timezone "${currentTz}". Allowing this run to proceed.`
-              );
-              core.setOutput("should_run", "true");
-              return;
-            }
 
             const formatter = new Intl.DateTimeFormat("en-CA", {
               timeZone: "America/Chicago",
@@ -118,7 +96,6 @@ jobs:
 
               const duplicates = runs
                 .filter((run) => run.id !== runId)
-                .filter((run) => activeTitles.includes(run.display_title))
                 .filter((run) => formatter.format(new Date(run.created_at)) === currentLocalDate)
                 .filter((run) => {
                   if (run.status !== "completed") {
@@ -147,13 +124,6 @@ jobs:
             }
 
             core.setOutput("should_run", "true");
-
-      - name: Finalize schedule decision
-        id: schedule-decision
-        if: always()
-        run: echo "should_run=$FINAL_SHOULD_RUN" >> "$GITHUB_OUTPUT"
-        env:
-          FINAL_SHOULD_RUN: ${{ steps.duplicate-check.outputs.should_run || steps.dst-check.outputs.should_run }}
 
   run-bot:
     runs-on: ${{ github.event_name == 'schedule' && 'macos-latest' || inputs.runner }}

--- a/README.md
+++ b/README.md
@@ -309,9 +309,9 @@ The bot can run automatically using GitHub Actions.
 ### Workflow Schedule
 
 The default schedule in `.github/workflows/bot.yml`:
-- **When**: 7:17 AM CT and 7:37 AM CT, Sunday through Thursday (DST-aware)
-- **Cron**: `17 12 * * 0-4` and `37 12 * * 0-4` during CDT; `17 13 * * 0-4` and `37 13 * * 0-4` during CST
-- **Guard rails**: `check-schedule` skips the wrong DST pair and also skips the backup run if an earlier valid scheduled run for that Chicago day is already active or already succeeded
+- **When**: 7:17 AM, 7:37 AM, 8:17 AM, 8:37 AM, and 9:17 AM CT, Sunday through Thursday
+- **Timezone**: Each schedule entry uses `timezone: "America/Chicago"`, so GitHub handles CDT/CST transitions directly
+- **Guard rails**: `check-schedule` skips a backup slot if an earlier scheduled run for that Chicago day is already active or already succeeded
 
 The runner starts early to absorb GitHub Actions scheduling delays (which regularly exceed an hour during weekday business hours); the bot then sleeps internally until `TARGET_LOCAL_TIME` (10:00 CT by default) before attempting the reservation 8 days in advance.
 


### PR DESCRIPTION
## Summary
- rename scheduled and manual workflow runs to use clearer, user-facing titles
- replace the UTC split schedule with timezone-aware America/Chicago schedule entries
- add extra same-morning fallback slots and keep the duplicate guard so only the first valid scheduled run proceeds
- update README schedule docs to match the workflow

## Validation
- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/bot.yml')"