### PR TITLE
Fix completion verification and backup suppression

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -86,33 +86,50 @@ jobs:
             });
 
             try {
-              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: "bot.yml",
-                event: "schedule",
-                per_page: 100,
-              });
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRuns,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: "bot.yml",
+                  event: "schedule",
+                  per_page: 100,
+                },
+                (response) => response.data.workflow_runs,
+              );
 
-              const duplicates = runs
+              const candidates = runs
                 .filter((run) => run.id !== runId)
                 .filter((run) => formatter.format(new Date(run.created_at)) === currentLocalDate)
-                .filter((run) => {
-                  if (run.status !== "completed") {
-                    return true;
-                  }
-                  return run.conclusion === "success";
-                })
                 .sort((left, right) => {
                   return new Date(left.created_at) - new Date(right.created_at);
                 });
 
-              if (duplicates.length > 0) {
-                const first = duplicates[0];
+              for (const run of candidates) {
+                const jobs = await github.paginate(
+                  github.rest.actions.listJobsForWorkflowRun,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                    per_page: 100,
+                  },
+                  (response) => response.data.jobs,
+                );
+                const runBotJob = jobs.find((job) => job.name === "run-bot");
+                if (!runBotJob) {
+                  continue;
+                }
+                const isActive = runBotJob.status !== "completed";
+                const isSuccessful = runBotJob.conclusion === "success";
+                if (!isActive && !isSuccessful) {
+                  continue;
+                }
                 core.notice(
-                  `Skipping duplicate scheduled run because ${first.display_title} ` +
-                  `(#${first.id}) is already ${first.status}` +
-                  `${first.conclusion ? `/${first.conclusion}` : ""} for ${currentLocalDate}.`
+                  `Skipping duplicate scheduled run because ${run.display_title} ` +
+                  `(#${run.id}) has run-bot ${runBotJob.status}` +
+                  `${runBotJob.conclusion ? `/${runBotJob.conclusion}` : ""} ` +
+                  `for ${currentLocalDate}.`
                 );
                 core.setOutput("should_run", "false");
                 return;

--- a/src/lifetime_bot/reservations.py
+++ b/src/lifetime_bot/reservations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import time
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -12,12 +14,31 @@ from lifetime_bot.errors import LifetimeAPIError
 from lifetime_bot.models import ClassEvent, RegistrationOutcome, RegistrationResult
 from lifetime_bot.parsers import extract_required_document_ids, match_class
 
+POST_COMPLETE_CONFIRMATION_ATTEMPTS = 6
+POST_COMPLETE_CONFIRMATION_DELAY_SECONDS = 2.0
+
 
 class ReservationService:
     """Encapsulates class lookup and reservation completion behavior."""
 
-    def __init__(self, client: LifetimeAPIClient) -> None:
+    def __init__(
+        self,
+        client: LifetimeAPIClient,
+        *,
+        post_complete_confirmation_attempts: int = POST_COMPLETE_CONFIRMATION_ATTEMPTS,
+        post_complete_confirmation_delay_seconds: float = (
+            POST_COMPLETE_CONFIRMATION_DELAY_SECONDS
+        ),
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
         self.client = client
+        self.post_complete_confirmation_attempts = max(
+            1, post_complete_confirmation_attempts
+        )
+        self.post_complete_confirmation_delay_seconds = max(
+            0.0, post_complete_confirmation_delay_seconds
+        )
+        self.sleep = sleep
 
     def find_target_event(
         self, *, club_name: str, target_class: ClassConfig, target_date: str
@@ -110,9 +131,7 @@ class ReservationService:
                 result.registration_id,
                 accepted_documents=accepted_documents,
             )
-            verified = self.detect_existing_registration(
-                event_id, context="post-complete"
-            )
+            verified = self._confirm_post_complete_registration(event_id)
             if verified is None:
                 raise LifetimeAPIError(
                     "PUT /complete succeeded, but follow-up registration info did "
@@ -198,6 +217,30 @@ class ReservationService:
             f"({self.client.member_id}) is already reserved for event {event_id}."
         )
         return RegistrationResult.already_reserved(info)
+
+    def _confirm_post_complete_registration(
+        self, event_id: str
+    ) -> RegistrationResult | None:
+        for attempt in range(1, self.post_complete_confirmation_attempts + 1):
+            verified = self.detect_existing_registration(
+                event_id,
+                context=(
+                    "post-complete"
+                    f" attempt {attempt}/{self.post_complete_confirmation_attempts}"
+                ),
+            )
+            if verified is not None:
+                return verified
+            if attempt == self.post_complete_confirmation_attempts:
+                return None
+            print(
+                "Registration state is not visible yet after PUT /complete; "
+                f"waiting {self.post_complete_confirmation_delay_seconds:g} seconds "
+                f"before verification retry {attempt + 1}/"
+                f"{self.post_complete_confirmation_attempts}."
+            )
+            self.sleep(self.post_complete_confirmation_delay_seconds)
+        return None
 
 
 def _find_registered_member(

--- a/tests/unit/test_reservations.py
+++ b/tests/unit/test_reservations.py
@@ -288,6 +288,7 @@ class TestReservationServiceReserveEvent:
     ) -> None:
         client = MagicMock()
         client.member_id = 110137193
+        sleep = MagicMock()
         client.get_registration_info.side_effect = [
             LifetimeAPIError("not found", status_code=404),
             {"registeredMembers": [], "unregisteredMembers": [{"agreementId": 77}]},
@@ -306,12 +307,17 @@ class TestReservationServiceReserveEvent:
             LifetimeAPIError,
             match="did not confirm a reserved or waitlisted outcome",
         ):
-            ReservationService(client).reserve_event("evt")
+            ReservationService(
+                client,
+                post_complete_confirmation_attempts=1,
+                sleep=sleep,
+            ).reserve_event("evt")
 
         client.complete_registration.assert_called_once_with(
             101,
             accepted_documents=[],
         )
+        sleep.assert_not_called()
         captured = capsys.readouterr().out
         assert (
             "Registration info payload lacked recognized waiver/document ids: "
@@ -321,3 +327,38 @@ class TestReservationServiceReserveEvent:
             "POST /event completion payload lacked recognized waiver/document ids: "
             '{"regId": 101, "regStatus": "pending"}'
         ) in captured
+
+    def test_retries_post_complete_verification_until_reserved(self) -> None:
+        client = MagicMock()
+        client.member_id = 110137193
+        sleep = MagicMock()
+        client.get_registration_info.side_effect = [
+            LifetimeAPIError("not found", status_code=404),
+            {
+                "registeredMembers": [],
+                "unregisteredMembers": [{"id": 110137193, "name": "Tyler"}],
+            },
+            {"registeredMembers": [{"id": 110137193, "name": "Tyler"}]},
+        ]
+        client.register.return_value = RegistrationResult(
+            registration_id=101,
+            outcome=RegistrationOutcome.PENDING_COMPLETION,
+            raw_status="pending",
+            needs_complete=True,
+            required_documents=(77,),
+            raw={"regId": 101, "regStatus": "pending"},
+        )
+
+        result = ReservationService(
+            client,
+            post_complete_confirmation_attempts=2,
+            post_complete_confirmation_delay_seconds=0.5,
+            sleep=sleep,
+        ).reserve_event("evt")
+
+        assert result.outcome is RegistrationOutcome.RESERVED
+        client.complete_registration.assert_called_once_with(
+            101,
+            accepted_documents=[77],
+        )
+        sleep.assert_called_once_with(0.5)


### PR DESCRIPTION
## Summary
- retry post-complete registration verification before classifying the reservation as failed
- stop suppressing later scheduled backups when an earlier scheduled workflow succeeded without a successful run-bot job
- add unit coverage for delayed post-complete registration confirmation

## Testing
- uv run pytest tests/unit
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/bot.yml')"
- git diff --check