### PR TITLE
Handle delayed waitlist confirmation

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -3,11 +3,11 @@ run-name: >-
   ${{
     github.event_name == 'schedule'
     && (
-      github.event.schedule == '17 7 * * 0-4' && 'Scheduled (CT primary)'
-      || github.event.schedule == '37 7 * * 0-4' && 'Scheduled (CT backup 1)'
-      || github.event.schedule == '17 8 * * 0-4' && 'Scheduled (CT backup 2)'
-      || github.event.schedule == '37 8 * * 0-4' && 'Scheduled (CT backup 3)'
-      || github.event.schedule == '17 9 * * 0-4' && 'Scheduled (CT final backup)'
+      github.event.schedule == '11 5 * * 0-4' && 'Scheduled (CT primary)'
+      || github.event.schedule == '27 5 * * 0-4' && 'Scheduled (CT backup 1)'
+      || github.event.schedule == '43 5 * * 0-4' && 'Scheduled (CT backup 2)'
+      || github.event.schedule == '9 6 * * 0-4' && 'Scheduled (CT backup 3)'
+      || github.event.schedule == '25 6 * * 0-4' && 'Scheduled (CT final backup)'
       || format('Scheduled ({0})', github.event.schedule)
     )
     || github.event_name == 'workflow_dispatch'
@@ -17,15 +17,15 @@ run-name: >-
 
 on:
   schedule:
-    - cron: '17 7 * * 0-4'   # 7:17 AM CT primary — 2h43m buffer before 10 AM CT target
+    - cron: '11 5 * * 0-4'   # 5:11 AM CT primary — 4h49m buffer before 10 AM CT target
       timezone: 'America/Chicago'
-    - cron: '37 7 * * 0-4'   # 7:37 AM CT backup 1 — 2h23m buffer before 10 AM CT target
+    - cron: '27 5 * * 0-4'   # 5:27 AM CT backup 1 — 4h33m buffer before 10 AM CT target
       timezone: 'America/Chicago'
-    - cron: '17 8 * * 0-4'   # 8:17 AM CT backup 2 — 1h43m buffer before 10 AM CT target
+    - cron: '43 5 * * 0-4'   # 5:43 AM CT backup 2 — 4h17m buffer before 10 AM CT target
       timezone: 'America/Chicago'
-    - cron: '37 8 * * 0-4'   # 8:37 AM CT backup 3 — 1h23m buffer before 10 AM CT target
+    - cron: '9 6 * * 0-4'    # 6:09 AM CT backup 3 — 3h51m buffer before 10 AM CT target
       timezone: 'America/Chicago'
-    - cron: '17 9 * * 0-4'   # 9:17 AM CT final backup — 43m buffer before 10 AM CT target
+    - cron: '25 6 * * 0-4'   # 6:25 AM CT final backup — 3h35m buffer before 10 AM CT target
       timezone: 'America/Chicago'
   workflow_dispatch:  # Allows manual trigger
     inputs:

--- a/README.md
+++ b/README.md
@@ -309,11 +309,11 @@ The bot can run automatically using GitHub Actions.
 ### Workflow Schedule
 
 The default schedule in `.github/workflows/bot.yml`:
-- **When**: 7:17 AM, 7:37 AM, 8:17 AM, 8:37 AM, and 9:17 AM CT, Sunday through Thursday
+- **When**: 5:11 AM, 5:27 AM, 5:43 AM, 6:09 AM, and 6:25 AM CT, Sunday through Thursday
 - **Timezone**: Each schedule entry uses `timezone: "America/Chicago"`, so GitHub handles CDT/CST transitions directly
 - **Guard rails**: `check-schedule` skips a backup slot if an earlier scheduled run for that Chicago day is already active or already succeeded
 
-The runner starts early to absorb GitHub Actions scheduling delays (which regularly exceed an hour during weekday business hours); the bot then sleeps internally until `TARGET_LOCAL_TIME` (10:00 CT by default) before attempting the reservation 8 days in advance.
+The runner starts early to absorb GitHub Actions scheduling delays (which can exceed three hours during weekday business hours); the bot then sleeps internally until `TARGET_LOCAL_TIME` (10:00 CT by default) before attempting the reservation 8 days in advance.
 
 For GitHub Actions runs, inline notifications are disabled during the reservation job. The bot writes a final JSON result payload, uploads it as an artifact, and the separate `notify` job sends the final email/SMS notification.
 

--- a/src/lifetime_bot/reservations.py
+++ b/src/lifetime_bot/reservations.py
@@ -151,6 +151,22 @@ class ReservationService:
             )
             verified = self._confirm_post_complete_registration(event_id)
             if verified is None:
+                if _is_pending_waitlist_result(pending_result):
+                    print(
+                        "PUT /complete succeeded for a full class with waitlist enabled, "
+                        "but follow-up registration info did not expose the waitlist "
+                        "state yet; treating the completed pending registration as "
+                        "waitlisted."
+                    )
+                    result = RegistrationResult(
+                        registration_id=pending_result.registration_id,
+                        outcome=RegistrationOutcome.WAITLISTED,
+                        raw_status="waitlisted",
+                        needs_complete=False,
+                        required_documents=pending_result.required_documents,
+                        raw=pending_result.raw,
+                    )
+                    return result
                 raise LifetimeAPIError(
                     "PUT /complete succeeded, but follow-up registration info did "
                     "not confirm a reserved or waitlisted outcome."
@@ -314,6 +330,32 @@ def _waitlist_position(member: dict[str, Any]) -> int | None:
     if isinstance(position, str) and position.isdigit():
         return int(position)
     return None
+
+
+def _is_pending_waitlist_result(result: RegistrationResult) -> bool:
+    if not result.needs_complete:
+        return False
+    payload = result.raw
+    has_waitlist = payload.get("hasWaitlist") is True
+    has_no_spots = payload.get("hasSpots") is False
+    open_spots = payload.get("openSpots")
+    roster_full = _validation_rule_message(payload, "rosterLimitRule")
+    return has_waitlist and (
+        has_no_spots or open_spots == 0 or "full" in roster_full.lower()
+    )
+
+
+def _validation_rule_message(payload: dict[str, Any], rule_name: str) -> str:
+    validation = payload.get("validation")
+    if not isinstance(validation, dict):
+        return ""
+    rules = validation.get("rules")
+    if not isinstance(rules, dict):
+        return ""
+    rule = rules.get(rule_name)
+    if not isinstance(rule, dict):
+        return ""
+    return str(rule.get("errorMessage") or "")
 
 
 def _log_payload(label: str, payload: Any) -> None:

--- a/tests/unit/test_reservations.py
+++ b/tests/unit/test_reservations.py
@@ -235,6 +235,49 @@ class TestReservationServiceReserveEvent:
             accepted_documents=[],
         )
 
+    def test_treats_unconfirmed_pending_full_waitlist_completion_as_waitlisted(
+        self,
+    ) -> None:
+        client = MagicMock()
+        client.member_id = 110137193
+        stale_registration_info = {
+            "registeredMembers": [],
+            "unregisteredMembers": [{"id": 110137193, "name": "Tyler"}],
+            "registerCta": True,
+        }
+        client.get_registration_info.side_effect = [
+            stale_registration_info,
+            stale_registration_info,
+            stale_registration_info,
+        ]
+        client.register.return_value = RegistrationResult(
+            registration_id=101,
+            outcome=RegistrationOutcome.PENDING_COMPLETION,
+            raw_status="pending",
+            needs_complete=True,
+            required_documents=None,
+            raw={
+                "regId": 101,
+                "regStatus": "pending",
+                "hasWaitlist": True,
+                "hasSpots": False,
+                "openSpots": 0,
+                "totalWaitlisted": 3,
+            },
+        )
+
+        result = ReservationService(
+            client,
+            post_complete_confirmation_attempts=1,
+        ).reserve_event("evt")
+
+        assert result.outcome is RegistrationOutcome.WAITLISTED
+        assert result.registration_id == 101
+        client.complete_registration.assert_called_once_with(
+            101,
+            accepted_documents=[],
+        )
+
     def test_skips_post_when_already_reserved(self) -> None:
         client = MagicMock()
         client.member_id = 110137193


### PR DESCRIPTION
## Summary
- Treat completed full-class waitlist registrations as waitlisted when Life Time's follow-up endpoint remains stale
- Move scheduled GitHub Actions runs earlier to absorb multi-hour scheduler delays
- Update README schedule documentation

## Verification
- uv run pytest
- uv run ruff check src/lifetime_bot/reservations.py tests/unit/test_reservations.py
- git diff --check
- Ruby YAML parse check for .github/workflows/bot.yml