### PR TITLE
Update reservation schedule for 7am class

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -3,11 +3,11 @@ run-name: >-
   ${{
     github.event_name == 'schedule'
     && (
-      github.event.schedule == '11 5 * * 0-4' && 'Scheduled (CT primary)'
-      || github.event.schedule == '27 5 * * 0-4' && 'Scheduled (CT backup 1)'
-      || github.event.schedule == '43 5 * * 0-4' && 'Scheduled (CT backup 2)'
-      || github.event.schedule == '9 6 * * 0-4' && 'Scheduled (CT backup 3)'
-      || github.event.schedule == '25 6 * * 0-4' && 'Scheduled (CT final backup)'
+      github.event.schedule == '11 4 * * 0-4' && 'Scheduled (CT primary)'
+      || github.event.schedule == '27 4 * * 0-4' && 'Scheduled (CT backup 1)'
+      || github.event.schedule == '43 4 * * 0-4' && 'Scheduled (CT backup 2)'
+      || github.event.schedule == '9 5 * * 0-4' && 'Scheduled (CT backup 3)'
+      || github.event.schedule == '25 5 * * 0-4' && 'Scheduled (CT final backup)'
       || format('Scheduled ({0})', github.event.schedule)
     )
     || github.event_name == 'workflow_dispatch'
@@ -17,15 +17,15 @@ run-name: >-
 
 on:
   schedule:
-    - cron: '11 5 * * 0-4'   # 5:11 AM CT primary — 4h49m buffer before 10 AM CT target
+    - cron: '11 4 * * 0-4'   # 4:11 AM CT primary - 4h49m buffer before 9 AM CT target
       timezone: 'America/Chicago'
-    - cron: '27 5 * * 0-4'   # 5:27 AM CT backup 1 — 4h33m buffer before 10 AM CT target
+    - cron: '27 4 * * 0-4'   # 4:27 AM CT backup 1 - 4h33m buffer before 9 AM CT target
       timezone: 'America/Chicago'
-    - cron: '43 5 * * 0-4'   # 5:43 AM CT backup 2 — 4h17m buffer before 10 AM CT target
+    - cron: '43 4 * * 0-4'   # 4:43 AM CT backup 2 - 4h17m buffer before 9 AM CT target
       timezone: 'America/Chicago'
-    - cron: '9 6 * * 0-4'    # 6:09 AM CT backup 3 — 3h51m buffer before 10 AM CT target
+    - cron: '9 5 * * 0-4'    # 5:09 AM CT backup 3 - 3h51m buffer before 9 AM CT target
       timezone: 'America/Chicago'
-    - cron: '25 6 * * 0-4'   # 6:25 AM CT final backup — 3h35m buffer before 10 AM CT target
+    - cron: '25 5 * * 0-4'   # 5:25 AM CT final backup - 3h35m buffer before 9 AM CT target
       timezone: 'America/Chicago'
   workflow_dispatch:  # Allows manual trigger
     inputs:

--- a/README.md
+++ b/README.md
@@ -309,11 +309,11 @@ The bot can run automatically using GitHub Actions.
 ### Workflow Schedule
 
 The default schedule in `.github/workflows/bot.yml`:
-- **When**: 5:11 AM, 5:27 AM, 5:43 AM, 6:09 AM, and 6:25 AM CT, Sunday through Thursday
+- **When**: 4:11 AM, 4:27 AM, 4:43 AM, 5:09 AM, and 5:25 AM CT, Sunday through Thursday
 - **Timezone**: Each schedule entry uses `timezone: "America/Chicago"`, so GitHub handles CDT/CST transitions directly
 - **Guard rails**: `check-schedule` skips a backup slot if an earlier scheduled run for that Chicago day is already active or already succeeded
 
-The runner starts early to absorb GitHub Actions scheduling delays (which can exceed three hours during weekday business hours); the bot then sleeps internally until `TARGET_LOCAL_TIME` (10:00 CT by default) before attempting the reservation 8 days in advance.
+The runner starts early to absorb GitHub Actions scheduling delays (which can exceed three hours during weekday business hours); the bot then sleeps internally until `TARGET_LOCAL_TIME` before attempting the reservation 8 days in advance.
 
 For GitHub Actions runs, inline notifications are disabled during the reservation job. The bot writes a final JSON result payload, uploads it as an artifact, and the separate `notify` job sends the final email/SMS notification.
 


### PR DESCRIPTION
## Summary
- shift scheduled workflow launch slots one hour earlier while preserving the existing delay buffers
- document the new default workflow launch times

## Notes
- prod GitHub Actions variables were updated separately to START_TIME=7:00 AM, END_TIME=8:00 AM, and TARGET_LOCAL_TIME=9:00:00

## Tests
- git diff --check